### PR TITLE
Promote canonical main-manifest switch to main

### DIFF
--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -4,5 +4,5 @@
   "latest_audited_version": "2.1.122",
   "latest_candidate_version": "2.1.122",
   "previous_stable_version": "2.1.121",
-  "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/dev/config/claude-termux-release-manifest.json"
+  "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -4,5 +4,5 @@
   "latest_audited_version": "2.1.122",
   "latest_candidate_version": "2.1.122",
   "previous_stable_version": "2.1.121",
-  "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/dev/config/claude-termux-release-manifest.json"
+  "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/scripts/update-release-manifest.js
+++ b/scripts/update-release-manifest.js
@@ -12,7 +12,7 @@ const manifestFiles = [
   path.join(repoRoot, 'config', 'claude-termux-release-manifest.json'),
   path.join(repoRoot, 'packages', 'claude-code', 'config', 'claude-termux-release-manifest.json'),
 ];
-const manifestUrl = 'https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/dev/config/claude-termux-release-manifest.json';
+const manifestUrl = 'https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json';
 
 function compareVersions(a, b) {
   const aParts = String(a).split('.').map(Number);


### PR DESCRIPTION
## Summary
- make the canonical manifest URL point to ClaudeCode-Termux main
- complete the bootstrap rollback from temporary dev manifest routing

## Verification
- node --check scripts/update-release-manifest.js
- node scripts/update-release-manifest.js