### PR TITLE
Promote Claude native 2.1.123

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -27,6 +27,13 @@
       "entry_js_offset": 232193716,
       "entry_end_offset": 246143358,
       "status": "termux_verified"
+    },
+    "2.1.123": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.123",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.123",
+      "entry_js_offset": 232194756,
+      "entry_end_offset": 246144430,
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.122",
-  "latest_candidate_version": "2.1.122",
-  "previous_stable_version": "2.1.121",
+  "latest_audited_version": "2.1.123",
+  "latest_candidate_version": "2.1.123",
+  "previous_stable_version": "2.1.122",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/docs/20260501_claude-native-2.1.123-design-review.md
+++ b/docs/20260501_claude-native-2.1.123-design-review.md
@@ -1,0 +1,39 @@
+# Claude Native 2.1.123 Design Review
+
+## STEP 1 計画固定
+
+- 対象: `ClaudeCode-Termux` canonical repo
+- 目的: upstream `@anthropic-ai/claude-code@2.1.123` を Termux wrapper の audited version として取り込む
+- 範囲:
+  - candidate intake
+  - Termux verification
+  - audited promotion
+  - canonical package publish 前提の metadata 更新
+
+## 事実
+
+- 2026-05-01 時点で `npm view @anthropic-ai/claude-code version dist-tags --json` は `latest=2.1.123` を返す
+- 現在の canonical metadata は `2.1.122` までしか持たない
+- 現在の canonical package version は `2.1.122`
+- `claude-native-version-watch.yml` は npm registry を正として candidate version を解決する
+
+## 推測
+
+- `2.1.123` は GitHub Releases 表示より npm publish が先行している可能性が高い
+- canonical repo 側では `2.1.123` を candidate intake し、Termux verification が通れば audited promotion してよい
+
+## STEP 2 設計判断
+
+- canonical repo を正規導線とする
+- `2.1.123` は最初に `offset_discovered` で追加し、その後 `termux_verified` へ昇格する
+- package version は audited promotion 後に `2.1.123` と一致させる
+- release manifest は `latest_candidate_version` と `latest_audited_version` を `2.1.123` へ更新する
+
+## STEP 4 再現条件・テスト観点
+
+- `node scripts/termux-prepare-claude-native-version.js @2.1.123 --json`
+- `CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 node packages/claude-code/lib/prepare-native.js 2.1.123`
+- `CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.123 sh packages/claude-code/bin/claude --version`
+- `CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.123 sh packages/claude-code/bin/claude auth status`
+- `CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.123 sh packages/claude-code/bin/claude update --dry-run`
+- temp prefix での `npm install -g --prefix ... ./packages/claude-code`

--- a/docs/20260501_claude-native-2.1.123-implementation-plan.md
+++ b/docs/20260501_claude-native-2.1.123-implementation-plan.md
@@ -1,0 +1,25 @@
+# Claude Native 2.1.123 Implementation Plan
+
+## STEP 3 実装プラン
+
+1. `scripts/termux-prepare-claude-native-version.js` で `2.1.123` の offset metadata を取得する
+2. `config/claude-native-audited-versions.json` と package 側 metadata に `2.1.123` を `offset_discovered` で追加する
+3. `node scripts/update-release-manifest.js` で candidate manifest を更新する
+4. Termux verification を実施する
+5. verification 成功後に `2.1.123` を `termux_verified` に昇格し、`packages/claude-code/package.json` を `2.1.123` に更新する
+6. `npm pack --dry-run ./packages/claude-code` で publish 前整合性を確認する
+
+## 対象ファイル
+
+- `config/claude-native-audited-versions.json`
+- `config/claude-termux-release-manifest.json`
+- `packages/claude-code/config/claude-native-audited-versions.json`
+- `packages/claude-code/config/claude-termux-release-manifest.json`
+- `packages/claude-code/package.json`
+
+## 完了条件
+
+- root/package metadata が一致する
+- `2.1.123` が `termux_verified`
+- manifest の `latest_audited_version` が `2.1.123`
+- canonical package version が `2.1.123`

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -27,6 +27,13 @@
       "entry_js_offset": 232193716,
       "entry_end_offset": 246143358,
       "status": "termux_verified"
+    },
+    "2.1.123": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.123",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.123",
+      "entry_js_offset": 232194756,
+      "entry_end_offset": 246144430,
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.122",
-  "latest_candidate_version": "2.1.122",
-  "previous_stable_version": "2.1.121",
+  "latest_audited_version": "2.1.123",
+  "latest_candidate_version": "2.1.123",
+  "previous_stable_version": "2.1.122",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.122",
+  "version": "2.1.123",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## Summary
- add audited metadata for Claude native 2.1.123
- verify 2.1.123 on Termux
- update canonical release manifest and package version to 2.1.123

## Verification
- node scripts/termux-prepare-claude-native-version.js @2.1.123 --json
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 node packages/claude-code/lib/prepare-native.js 2.1.123
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.123 sh packages/claude-code/bin/claude --version
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.123 sh packages/claude-code/bin/claude auth status
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.123 sh packages/claude-code/bin/claude update --dry-run
- npm install -g --prefix /data/data/com.termux/files/usr/tmp/claude-termux-2.1.123-prefix ./packages/claude-code
- npm pack --dry-run ./packages/claude-code