### PR TITLE
Automate local-gated canonical release flow

### DIFF
--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -7,6 +7,10 @@ on:
         description: "Claude Code version or @latest"
         required: false
         default: "@latest"
+      base_branch:
+        description: "Base branch for candidate PR"
+        required: false
+        default: "dev"
   schedule:
     - cron: "17 3 * * *"
 
@@ -19,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.base_branch || 'dev' }}
 
       - uses: actions/setup-node@v4
         with:
@@ -126,13 +132,14 @@ jobs:
           If upstream package structure changed, close this PR and update the native preparation script.
           EOF
           )"
-          existing_pr="$(gh pr list --head "${branch}" --base main --state open --json url --jq '.[0].url // ""')"
+          base="${{ github.event.inputs.base_branch || 'dev' }}"
+          existing_pr="$(gh pr list --head "${branch}" --base "${base}" --state open --json url --jq '.[0].url // ""')"
           if [ -n "${existing_pr}" ]; then
             echo "Existing PR: ${existing_pr}"
             exit 0
           fi
           gh pr create \
-            --base main \
+            --base "${base}" \
             --head "${branch}" \
             --title "${title}" \
             --body "${body}"

--- a/.github/workflows/dispatch-legacy-sync.yml
+++ b/.github/workflows/dispatch-legacy-sync.yml
@@ -1,0 +1,44 @@
+name: Dispatch Legacy Sync
+
+on:
+  workflow_run:
+    workflows:
+      - Npm Package
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.event == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Resolve audited version
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync("config/claude-termux-release-manifest.json","utf8"));process.stdout.write(String(j.latest_audited_version||""))')"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Dispatch legacy sync workflow
+        env:
+          GH_TOKEN: ${{ secrets.LEGACY_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "LEGACY_REPO_TOKEN is not configured."
+            exit 1
+          fi
+          gh workflow run sync-canonical-metadata.yml \
+            --repo bash0816/CluadeCode-Termux \
+            --ref main \
+            -f version=${{ steps.version.outputs.version }} \
+            -f base_branch=dev

--- a/.github/workflows/promote-dev-to-staging.yml
+++ b/.github/workflows/promote-dev-to-staging.yml
@@ -1,0 +1,34 @@
+name: Promote Dev To Staging
+
+on:
+  workflow_run:
+    workflows:
+      - Npm Package
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  promote:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open PR to staging
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          existing_pr="$(gh pr list --repo bash0816/ClaudeCode-Termux --head dev --base staging --state open --json url --jq '.[0].url // ""')"
+          if [ -n "${existing_pr}" ]; then
+            echo "Existing PR: ${existing_pr}"
+            exit 0
+          fi
+          gh pr create \
+            --repo bash0816/ClaudeCode-Termux \
+            --base staging \
+            --head dev \
+            --title "Promote canonical release flow to staging" \
+            --body "Automated dev to staging promotion for canonical release metadata."

--- a/.github/workflows/promote-feature-to-dev.yml
+++ b/.github/workflows/promote-feature-to-dev.yml
@@ -1,0 +1,42 @@
+name: Promote Feature To Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      head_branch:
+        description: "Feature branch to promote into dev"
+        required: true
+      title:
+        description: "Optional PR title"
+        required: false
+        default: ""
+      body:
+        description: "Optional PR body"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open PR to dev
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          head_branch="${{ inputs.head_branch }}"
+          title="${{ inputs.title }}"
+          body="${{ inputs.body }}"
+          if [ -z "${title}" ]; then
+            title="Promote ${head_branch} to dev"
+          fi
+          existing_pr="$(gh pr list --repo bash0816/ClaudeCode-Termux --head "${head_branch}" --base dev --state open --json url --jq '.[0].url // ""')"
+          if [ -n "${existing_pr}" ]; then
+            echo "Existing PR: ${existing_pr}"
+            exit 0
+          fi
+          gh pr create --repo bash0816/ClaudeCode-Termux --base dev --head "${head_branch}" --title "${title}" --body "${body:-Automated promotion to dev.}"

--- a/.github/workflows/promote-staging-to-main.yml
+++ b/.github/workflows/promote-staging-to-main.yml
@@ -1,0 +1,34 @@
+name: Promote Staging To Main
+
+on:
+  workflow_run:
+    workflows:
+      - Npm Package
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  promote:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'staging'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open PR to main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          existing_pr="$(gh pr list --repo bash0816/ClaudeCode-Termux --head staging --base main --state open --json url --jq '.[0].url // ""')"
+          if [ -n "${existing_pr}" ]; then
+            echo "Existing PR: ${existing_pr}"
+            exit 0
+          fi
+          gh pr create \
+            --repo bash0816/ClaudeCode-Termux \
+            --base main \
+            --head staging \
+            --title "Release canonical audited version to main" \
+            --body "Automated staging to main promotion for canonical audited metadata."

--- a/.github/workflows/promote-verified-candidate.yml
+++ b/.github/workflows/promote-verified-candidate.yml
@@ -10,7 +10,7 @@ on:
       base_branch:
         description: "Base branch for the promotion PR"
         required: false
-        default: "main"
+        default: "dev"
 
 permissions:
   contents: write

--- a/.github/workflows/publish-audited-release.yml
+++ b/.github/workflows/publish-audited-release.yml
@@ -1,0 +1,47 @@
+name: Publish Audited Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "config/**"
+      - "packages/claude-code/**"
+      - "scripts/**"
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Resolve publish need
+        id: status
+        run: |
+          set -euo pipefail
+          node scripts/release-automation-status.js --json > status.json
+          audited_version="$(node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync("status.json","utf8"));process.stdout.write(String(j.latest_audited_version||""))')"
+          needs_publish="$(node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync("status.json","utf8"));process.stdout.write(String(j.needs_publish))')"
+          echo "audited_version=${audited_version}" >> "${GITHUB_OUTPUT}"
+          echo "needs_publish=${needs_publish}" >> "${GITHUB_OUTPUT}"
+
+      - name: Dispatch npm publish workflow
+        if: steps.status.outputs.needs_publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run npm-package.yml \
+            --ref main \
+            -f publish=true \
+            -f package_version=${{ steps.status.outputs.audited_version }} \
+            -f npm_tag=latest

--- a/docs/20260501_local-codex-gated-release-design-review.md
+++ b/docs/20260501_local-codex-gated-release-design-review.md
@@ -1,0 +1,130 @@
+# Local Codex Gated Release Design Review
+
+## STEP 1 計画固定
+
+- 対象: `ClaudeCode-Termux` canonical release automation
+- 目的: この端末の `crontab` から `codex exec` を自動起動し、Termux 実機検証だけを local で実行し、その後の promotion / publish / legacy sync を GitHub Actions 側へ戻す
+- 範囲:
+  - candidate intake 後の local verification gate
+  - branch promotion automation
+  - canonical npm publish automation
+  - legacy metadata sync automation
+
+## 事実
+
+- 現在の cron 登録は legacy repo の script を叩いている  
+  `30 9 * * * /bin/sh /data/data/com.termux/files/home/CluadeCode-Termux-public/scripts/run-local-release-automation.sh ...`
+- canonical repo には local follow-up automation script がある  
+  `scripts/run-local-release-automation.sh`
+- canonical repo には candidate intake workflow がある  
+  `.github/workflows/claude-native-version-watch.yml`
+- canonical repo には verified promotion workflow がある  
+  `.github/workflows/promote-verified-candidate.yml`
+- canonical repo には npm publish workflow がある  
+  `.github/workflows/npm-package.yml`
+- 現在の local automation は
+  - candidate verification が必要か
+  - publish が必要か
+  の 2 モードしか持たない
+- 現在の GitHub Actions は `feature/* -> dev -> staging -> main` を自動昇格しない
+- 現在の legacy sync は別 repo に対して手動で PR / merge している
+
+## 推測
+
+- 既存構成を最大活用するなら、local Codex は「実機でしかできない verification gate」に責務を限定した方がよい
+- branch promotion と publish と legacy sync は GitHub Actions 側に戻した方がログが一元化される
+- local script から直接 `git push` や `gh pr merge` を多用するより、workflow dispatch を段階的に投げる方が rollback しやすい
+- cron の重複実行は避けられないので、candidate verification には local idempotency state が必要
+
+## STEP 2 設計判断
+
+### 正規フロー
+
+1. GitHub Actions が upstream candidate を検出する
+2. candidate metadata branch / PR を `dev` 向けに自動作成する
+3. この端末の `cron` が canonical repo の `run-local-release-automation.sh` を起動する
+4. local status script が
+   - candidate version
+   - published canonical version
+   - legacy main synced version
+   - local verification state
+   を集約して mode を決める
+5. local Codex が candidate version を実機検証する
+6. 検証成功時のみ GitHub Actions の verified promotion workflow を `dev` 向けに dispatch する
+7. GitHub Actions が verified promotion branch を作成し、`feature -> dev` PR を開く
+8. `dev` 反映後の workflow が `dev -> staging` PR を作る
+9. `staging` 反映後の workflow が `staging -> main` PR を作る
+10. canonical `main` 更新後の workflow が canonical publish workflow を dispatch する
+11. canonical publish 成功後の workflow が legacy sync workflow を dispatch する
+12. legacy repo でも `feature -> dev -> staging -> main` を順に昇格する
+
+### local Codex の責務
+
+- candidate version の Termux 実機 verification
+- 失敗時の停止と結果記録
+- 成功時の verified promotion workflow dispatch
+- publish や legacy sync は行わない
+
+### GitHub Actions の責務
+
+- metadata candidate branch / PR 作成
+- verified metadata promotion branch / PR 作成
+- branch promotion PR 作成
+- canonical npm publish
+- legacy sync branch / PR 作成
+
+### Source Of Truth
+
+- candidate / audited state:
+  - canonical repo の各 branch manifest
+- publish state:
+  - npm registry の `@bash0816/claude-code`
+- legacy sync state:
+  - legacy repo `origin/main:config/claude-termux-release-manifest.json`
+- local verification idempotency state:
+  - `${HOME}/.codex-release-cicd/state/canonical-release-state.json`
+
+### 停止条件
+
+- local verification のどれか 1 つでも失敗したら promotion を dispatch しない
+- local state に `verification_in_progress` または `promotion_dispatched_for_candidate` がある candidate は再検証しない
+- canonical `dev/staging/main` のどこかで verify workflow が落ちたら次段 promotion を作らない
+- canonical publish が失敗したら legacy sync を開始しない
+
+## STEP 4 再現条件・テスト観点
+
+- cron が canonical repo の script を叩くこと
+- `release-automation-status.js --json` が
+  - `needs_verification`
+  - `needs_publish`
+  - `needs_legacy_sync`
+  - `local_verification_locked`
+  を判定できること
+- local Codex が candidate verification 成功時だけ verified promotion workflow を dispatch すること
+- local Codex が publish workflow を dispatch しないこと
+- `feature -> dev -> staging -> main` の PR 生成が workflow で段階的に行えること
+- canonical publish 成功後にだけ legacy sync workflow が動くこと
+- 同じ candidate で cron を複数回回しても verification が多重起動しないこと
+
+## 主要リスク
+
+- cron が legacy repo の script を叩いたままだと canonical automation が始まらない
+- local Codex が `main` 以外を clone して誤判定すると publish 条件が崩れる
+- branch promotion を一気に自動 merge すると、途中検証失敗時の停止点が分かりにくくなる
+- legacy sync を publish 前に走らせると、既存利用者が未公開 canonical version を参照する危険がある
+- local state が壊れると verification lock が残るので、手動解除手順が必要
+
+## Rollback
+
+- local verification lock は state file を削除して解除する
+- candidate PR / promotion PR は該当 branch を close して再実行する
+- publish 失敗時は canonical `main` を維持したまま legacy sync を止める
+- legacy sync 失敗時は canonical publish 済みを維持し、legacy repo だけ再同期する
+
+## 設計結論
+
+- local Codex は verification gate に限定する
+- cron の正規起動先は canonical repo に切り替えるが、切り替えは runner/workflow 完成後に行う
+- publish の起動主体は GitHub Actions follow-up workflow に一本化する
+- その後段の promotion / publish / legacy sync は GitHub Actions の多段 workflow へ戻す
+- legacy repo は canonical publish 成功後に同期する従系として扱う

--- a/docs/20260501_local-codex-gated-release-implementation-plan.md
+++ b/docs/20260501_local-codex-gated-release-implementation-plan.md
@@ -1,0 +1,101 @@
+# Local Codex Gated Release Implementation Plan
+
+## STEP 3 実装プラン
+
+1. `scripts/release-automation-status.js` を拡張して、少なくとも次を返せるようにする
+   - `needs_verification`
+   - `needs_legacy_sync`
+   - `latest_legacy_synced_version`
+   - `local_verification_locked`
+   - `local_state_file`
+2. local state file を導入して、candidate ごとの
+   - `verification_in_progress`
+   - `verification_failed`
+   - `promotion_dispatched`
+   を記録する
+3. `scripts/run-local-release-automation.sh` を拡張して、candidate verification 成功後に canonical verified promotion workflow だけを dispatch する
+4. `scripts/run-local-release-automation.sh` から publish dispatch 分岐を削除する
+5. canonical repo に branch promotion workflow を追加する
+   - `promote-feature-to-dev.yml`
+   - `promote-dev-to-staging.yml`
+   - `promote-staging-to-main.yml`
+6. canonical repo の candidate intake / verified promotion workflow を `dev` 基準へ変更する
+7. canonical repo に publish follow-up workflow を追加する
+   - `publish-audited-release.yml`
+   - canonical `main` の audited version を npm publish
+8. legacy sync 用 workflow を canonical 側または legacy 側に追加する
+   - canonical publish 成功後に dispatch
+   - legacy metadata branch / PR を作る
+9. legacy repo にも branch promotion workflow を追加する
+   - `feature -> dev`
+   - `dev -> staging`
+   - `staging -> main`
+10. `scripts/install-local-release-cron.sh` に
+   - `--dry-run`
+   - backup 出力
+   - canonical path への明示切替
+   を追加する
+11. local automation の dry-run と end-to-end dispatch path を検証する
+12. 最後に cron を canonical repo へ切り替える
+
+## 実装方針
+
+### local script 側
+
+- 直接 `git push` や `gh pr merge` はしない
+- verified promotion workflow dispatch のみを行う
+- local result JSON に
+  - verification 結果
+  - dispatch 成否
+  - dispatch 済み candidate version
+  - local state file path
+  を残す
+
+### workflow 側
+
+- 1 workflow 1責務に分ける
+- merge 先 branch を inputs で固定できるようにする
+- 各段で verify job を再実行し、成功したときだけ次 workflow を起動する
+- canonical publish は `staging -> main` 完了後の follow-up workflow だけが起動する
+
+### legacy 側
+
+- package publish は新規には行わない
+- metadata / manifest 同期だけを自動化する
+- legacy package version は bridge version のまま維持する
+
+## 対象ファイル
+
+- `scripts/run-local-release-automation.sh`
+- `scripts/release-automation-status.js`
+- `scripts/install-local-release-cron.sh`
+- `.github/workflows/claude-native-version-watch.yml`
+- `.github/workflows/promote-verified-candidate.yml`
+- `.github/workflows/npm-package.yml`
+- `.github/workflows/publish-audited-release.yml`
+- `.github/workflows/promote-feature-to-dev.yml`
+- `.github/workflows/promote-dev-to-staging.yml`
+- `.github/workflows/promote-staging-to-main.yml`
+- 新規 workflow 複数
+- legacy repo の sync / promotion workflows
+
+## 完了条件
+
+- cron が canonical repo の local automation を起動する
+- candidate 検出後、local Codex が自動で verification し、成功時に canonical promotion workflow を dispatch する
+- local Codex は publish workflow を dispatch しない
+- canonical `main` までの昇格が workflow で追跡できる
+- canonical publish 成功後にだけ legacy sync が走る
+- 既存利用者は legacy package から canonical package へ安全に移行できる
+- 同一 candidate に対する cron の多重検証が local state で抑止される
+
+## 実装順
+
+1. local status / runner 拡張
+2. candidate / verified workflow の `dev` 基準化
+3. canonical branch promotion workflows
+4. canonical publish follow-up
+5. legacy sync automation
+6. cron installer hardening
+7. end-to-end dry-run
+8. 最後に cron 切り替え

--- a/scripts/install-local-release-cron.sh
+++ b/scripts/install-local-release-cron.sh
@@ -4,17 +4,29 @@ set -eu
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
 CRON_MINUTE="${1:-30}"
+DRY_RUN=0
+if [ "${CRON_MINUTE}" = "--dry-run" ]; then
+  DRY_RUN=1
+  CRON_MINUTE="${2:-30}"
+fi
 CRON_LINE="${CRON_MINUTE} 9 * * * /bin/sh ${REPO_ROOT}/scripts/run-local-release-automation.sh >> ${HOME}/.codex-release-cicd/cron.log 2>&1"
 
 if command -v crontab >/dev/null 2>&1; then
   current_file=$(mktemp)
   next_file=$(mktemp)
+  backup_file="${HOME}/.codex-release-cicd/crontab.backup.$(date -u +%Y%m%dT%H%M%SZ)"
   trap 'rm -f "${current_file}" "${next_file}"' EXIT
   crontab -l > "${current_file}" 2>/dev/null || true
+  mkdir -p "${HOME}/.codex-release-cicd"
+  cp "${current_file}" "${backup_file}" 2>/dev/null || true
   grep -v 'run-local-release-automation.sh' "${current_file}" > "${next_file}" || true
   printf '%s\n' "${CRON_LINE}" >> "${next_file}"
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    printf 'dry-run cron entry:\n%s\nbackup: %s\n' "${CRON_LINE}" "${backup_file}"
+    exit 0
+  fi
   crontab "${next_file}"
-  printf 'installed cron entry:\n%s\n' "${CRON_LINE}"
+  printf 'installed cron entry:\n%s\nbackup: %s\n' "${CRON_LINE}" "${backup_file}"
   exit 0
 fi
 

--- a/scripts/release-automation-status.js
+++ b/scripts/release-automation-status.js
@@ -3,11 +3,14 @@
 
 const cp = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const repoRoot = path.resolve(__dirname, '..');
 const manifestPath = path.join(repoRoot, 'config', 'claude-termux-release-manifest.json');
 const packageName = '@bash0816/claude-code';
+const legacyRepoRoot = process.env.CLAUDE_TERMUX_LEGACY_REPO_ROOT || path.join(os.homedir(), 'CluadeCode-Termux-public');
+const stateFile = process.env.CLAUDE_TERMUX_STATE_FILE || path.join(os.homedir(), '.codex-release-cicd', 'state', 'canonical-release-state.json');
 const jsonOnly = process.argv.includes('--json');
 
 function compareVersions(a, b) {
@@ -21,47 +24,109 @@ function compareVersions(a, b) {
   return 0;
 }
 
-function run(command, args) {
+function run(command, args, cwd = repoRoot, allowFailure = false) {
   const result = cp.spawnSync(command, args, {
-    cwd: repoRoot,
+    cwd,
     encoding: 'utf8',
   });
-  if (result.status !== 0) {
+  if (result.status !== 0 && !allowFailure) {
     throw new Error(`${command} ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
   }
-  return result.stdout.trim();
+  return {
+    status: result.status,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
 }
 
-function loadMainManifest() {
+function loadJsonFile(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function readState() {
   try {
-    const raw = run('git', ['show', 'origin/main:config/claude-termux-release-manifest.json']);
+    return loadJsonFile(stateFile);
+  } catch {
+    return { candidates: {} };
+  }
+}
+
+function loadManifestFromGit(cwd, ref) {
+  try {
+    const raw = run('git', ['show', `${ref}:config/claude-termux-release-manifest.json`], cwd).stdout;
     return JSON.parse(raw);
   } catch {
-    return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    return null;
   }
+}
+
+function listRemoteBranches(prefix) {
+  const result = run('git', ['for-each-ref', '--format=%(refname:short)', `refs/remotes/origin/${prefix}`]);
+  return result.stdout ? result.stdout.split('\n').map(line => line.trim()).filter(Boolean) : [];
+}
+
+function extractVersionFromBranch(branch, prefix) {
+  const marker = `origin/${prefix}`;
+  if (!branch.startsWith(marker)) return '';
+  return branch.slice(marker.length);
+}
+
+function maxVersion(versions) {
+  return versions.slice().sort(compareVersions).pop() || '';
 }
 
 function loadPublishedVersion() {
-  try {
-    return run('npm', ['view', packageName, 'version']);
-  } catch {
-    return '';
+  const result = run('npm', ['view', packageName, 'version'], repoRoot, true);
+  return result.status === 0 ? result.stdout : '';
+}
+
+function loadLegacyMainManifest() {
+  if (!fs.existsSync(legacyRepoRoot)) {
+    return null;
   }
+  run('git', ['fetch', '--prune', 'origin'], legacyRepoRoot, true);
+  return loadManifestFromGit(legacyRepoRoot, 'origin/main');
+}
+
+function loadCandidateVersion(mainAuditedVersion) {
+  const branches = listRemoteBranches('automation/native-claude-');
+  const versions = branches
+    .map(branch => extractVersionFromBranch(branch, 'automation/native-claude-'))
+    .filter(version => compareVersions(version, mainAuditedVersion) > 0);
+  return maxVersion(versions);
+}
+
+function isLocalVerificationLocked(state, version) {
+  if (!version) return false;
+  const item = state.candidates && state.candidates[version];
+  if (!item) return false;
+  return item.status === 'verification_in_progress' || item.status === 'promotion_dispatched';
 }
 
 function main() {
-  const manifest = loadMainManifest();
+  const localManifest = loadJsonFile(manifestPath);
+  const mainManifest = loadManifestFromGit(repoRoot, 'origin/main') || localManifest;
+  const devManifest = loadManifestFromGit(repoRoot, 'origin/dev') || mainManifest;
   const publishedVersion = loadPublishedVersion();
-  const latestAudited = manifest.latest_audited_version || '';
-  const latestCandidate = manifest.latest_candidate_version || '';
+  const legacyManifest = loadLegacyMainManifest();
+  const state = readState();
+
+  const latestAudited = mainManifest.latest_audited_version || '';
+  const latestCandidate = loadCandidateVersion(latestAudited) || devManifest.latest_candidate_version || latestAudited;
+  const latestLegacySyncedVersion = legacyManifest ? (legacyManifest.latest_audited_version || '') : '';
+  const localVerificationLocked = isLocalVerificationLocked(state, latestCandidate);
 
   const result = {
     package_name: packageName,
     latest_audited_version: latestAudited,
     latest_candidate_version: latestCandidate,
     published_version: publishedVersion,
-    needs_verification: compareVersions(latestCandidate, latestAudited) > 0,
+    latest_legacy_synced_version: latestLegacySyncedVersion,
+    local_verification_locked: localVerificationLocked,
+    local_state_file: stateFile,
+    needs_verification: Boolean(latestCandidate) && compareVersions(latestCandidate, latestAudited) > 0 && !localVerificationLocked,
     needs_publish: publishedVersion ? compareVersions(latestAudited, publishedVersion) > 0 : false,
+    needs_legacy_sync: latestLegacySyncedVersion ? compareVersions(latestAudited, latestLegacySyncedVersion) > 0 : false,
   };
 
   if (jsonOnly) {

--- a/scripts/run-local-release-automation.sh
+++ b/scripts/run-local-release-automation.sh
@@ -3,14 +3,16 @@ set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
+ORIGIN_URL="${CLAUDE_TERMUX_AUTOMATION_ORIGIN_URL:-$(git -C "${REPO_ROOT}" config --get remote.origin.url 2>/dev/null || printf '%s' "${REPO_ROOT}")}"
 AUTOMATION_ROOT="${CLAUDE_TERMUX_AUTOMATION_ROOT:-${HOME}/.codex-release-cicd}"
 WORK_ROOT="${AUTOMATION_ROOT}/work"
 LOG_ROOT="${AUTOMATION_ROOT}/logs"
+STATE_ROOT="${AUTOMATION_ROOT}/state"
+STATE_FILE="${CLAUDE_TERMUX_STATE_FILE:-${STATE_ROOT}/canonical-release-state.json}"
 SCHEMA_FILE="${REPO_ROOT}/scripts/codex-release-automation-output.schema.json"
-SOURCE_REF="${CLAUDE_TERMUX_AUTOMATION_SOURCE_REF:-$(git -C "${REPO_ROOT}" branch --show-current 2>/dev/null || printf 'main')}"
-BASE_BRANCH="${CLAUDE_TERMUX_AUTOMATION_BASE_BRANCH:-main}"
+SOURCE_REF="${CLAUDE_TERMUX_AUTOMATION_SOURCE_REF:-main}"
+BASE_BRANCH="${CLAUDE_TERMUX_AUTOMATION_BASE_BRANCH:-dev}"
 WORKFLOW_REF="${CLAUDE_TERMUX_AUTOMATION_WORKFLOW_REF:-main}"
-NPM_TAG="${CLAUDE_TERMUX_AUTOMATION_NPM_TAG:-latest}"
 DRY_RUN=0
 
 if [ "${1:-}" = "--dry-run" ]; then
@@ -25,10 +27,11 @@ result_json="${log_dir}/result.json"
 last_message="${log_dir}/last-message.json"
 
 mkdir -p "${run_dir}" "${log_dir}"
+mkdir -p "${STATE_ROOT}"
 
-git clone "${REPO_ROOT}" "${run_dir}/repo" >/dev/null 2>&1
+git clone "${ORIGIN_URL}" "${run_dir}/repo" >/dev/null 2>&1
 git -C "${run_dir}/repo" fetch --prune origin >/dev/null 2>&1
-git -C "${run_dir}/repo" checkout "${SOURCE_REF}" >/dev/null 2>&1 || true
+git -C "${run_dir}/repo" checkout -B "${SOURCE_REF}" "origin/${SOURCE_REF}" >/dev/null 2>&1 || true
 git -C "${run_dir}/repo" pull --ff-only origin "${SOURCE_REF}" >/dev/null 2>&1 || true
 
 node "${run_dir}/repo/scripts/release-automation-status.js" --json > "${status_json}"
@@ -42,18 +45,65 @@ audited_version=$(read_json_field "${status_json}" latest_audited_version)
 published_version=$(read_json_field "${status_json}" published_version)
 needs_verification=$(read_json_field "${status_json}" needs_verification)
 needs_publish=$(read_json_field "${status_json}" needs_publish)
+needs_legacy_sync=$(read_json_field "${status_json}" needs_legacy_sync)
+local_verification_locked=$(read_json_field "${status_json}" local_verification_locked)
+local_state_file=$(read_json_field "${status_json}" local_state_file)
 
-if [ "${needs_verification}" != "true" ] && [ "${needs_publish}" != "true" ]; then
+write_state() {
+  version="$1"
+  status="$2"
+  node - <<'NODE' "${STATE_FILE}" "${version}" "${status}"
+const fs = require('fs');
+const file = process.argv[2];
+const version = process.argv[3];
+const status = process.argv[4];
+let state = { candidates: {} };
+try {
+  state = JSON.parse(fs.readFileSync(file, 'utf8'));
+} catch {}
+if (!state.candidates) state.candidates = {};
+state.candidates[version] = {
+  status,
+  updated_at: new Date().toISOString()
+};
+fs.mkdirSync(require('path').dirname(file), { recursive: true });
+fs.writeFileSync(file, JSON.stringify(state, null, 2) + '\n');
+NODE
+}
+
+apply_result_state() {
+  if [ ! -f "${result_json}" ]; then
+    write_state "${candidate_version}" "verification_failed"
+    return
+  fi
+  result_candidate=$(read_json_field "${result_json}" candidate_version)
+  result_passed=$(read_json_field "${result_json}" verification_passed)
+  result_dispatched=$(read_json_field "${result_json}" promotion_dispatched)
+  if [ "${result_candidate}" = "${candidate_version}" ] && [ "${result_passed}" = "true" ] && [ "${result_dispatched}" = "true" ]; then
+    write_state "${candidate_version}" "promotion_dispatched"
+    return
+  fi
+  write_state "${candidate_version}" "verification_failed"
+}
+
+if [ "${needs_verification}" != "true" ]; then
+  note="no candidate verification required"
+  if [ "${local_verification_locked}" = "true" ]; then
+    note="candidate verification locked by local state"
+  elif [ "${needs_publish}" = "true" ]; then
+    note="canonical publish pending in GitHub Actions follow-up"
+  elif [ "${needs_legacy_sync}" = "true" ]; then
+    note="legacy sync pending in GitHub Actions follow-up"
+  fi
   cat > "${result_json}" <<EOF
-{"mode":"no_action","candidate_version":null,"audited_version":"${audited_version}","published_version":"${published_version}","verification_passed":false,"promotion_dispatched":false,"publish_dispatched":false,"notes":["no candidate verification or publish action required"]} 
+{"mode":"no_action","candidate_version":null,"audited_version":"${audited_version}","published_version":"${published_version}","verification_passed":false,"promotion_dispatched":false,"publish_dispatched":false,"notes":["${note}","state_file=${local_state_file}"]} 
 EOF
   cat "${result_json}"
   exit 0
 fi
 
-if [ "${needs_verification}" = "true" ]; then
-  prompt_file="${log_dir}/prompt.txt"
-  cat > "${prompt_file}" <<EOF
+prompt_file="${log_dir}/prompt.txt"
+cat > "${prompt_file}" <<EOF
 Use skill cluade-termux-release-cicd.
 
 Facts:
@@ -62,6 +112,7 @@ Facts:
 - Latest candidate version on main manifest: ${candidate_version}
 - Promotion target base branch: ${BASE_BRANCH}
 - Promotion workflow ref: ${WORKFLOW_REF}
+- Local state file: ${local_state_file}
 
 Task:
 1. Verify candidate version ${candidate_version} on this Termux environment.
@@ -71,29 +122,6 @@ Task:
 4. Do not push code changes.
 5. Final answer must be JSON matching the provided schema.
 EOF
-elif [ "${needs_publish}" = "true" ]; then
-  prompt_file="${log_dir}/prompt.txt"
-  cat > "${prompt_file}" <<EOF
-Use skill cluade-termux-release-cicd.
-
-Facts:
-- Repository: ${run_dir}/repo
-- Latest audited version on main manifest: ${audited_version}
-- Currently published npm version: ${published_version}
-- Publish workflow ref: ${WORKFLOW_REF}
-- npm tag: ${NPM_TAG}
-
-Task:
-1. Confirm that audited version ${audited_version} is the intended release version.
-2. Run lightweight consistency checks for manifest and package state.
-3. If and only if publish is still required, run:
-   gh workflow run npm-package.yml --repo bash0816/ClaudeCode-Termux --ref ${WORKFLOW_REF} -f publish=true -f package_version=${audited_version} -f npm_tag=${NPM_TAG}
-4. Do not push code changes.
-5. Final answer must be JSON matching the provided schema.
-EOF
-else
-  exit 1
-fi
 
 if [ "${DRY_RUN}" -eq 1 ]; then
   cat "${status_json}"
@@ -101,12 +129,15 @@ if [ "${DRY_RUN}" -eq 1 ]; then
   exit 0
 fi
 
+write_state "${candidate_version}" "verification_in_progress"
 codex exec \
   --full-auto \
   --skip-git-repo-check \
   -C "${run_dir}/repo" \
   --output-schema "${SCHEMA_FILE}" \
   -o "${last_message}" \
-  "$(cat "${prompt_file}")" > "${result_json}"
+  "$(cat "${prompt_file}")" > "${result_json}" || true
+
+apply_result_state
 
 cat "${result_json}"


### PR DESCRIPTION
## Summary
- constrain local Codex to Termux verification gate only
- add candidate lock state and legacy sync status detection
- move canonical promotions to dev/staging/main workflow chain
- add publish follow-up and legacy sync dispatch workflows
- harden cron installer with dry-run and backup

## Review gate
- GPT-5.5 reviewer verdict: Conditional Go
- blocker: none
- cron cutover and staging/main promotion remain gated on Actions execution confirmation and Termux validation

## Validation
- node --check scripts/release-automation-status.js
- sh -n scripts/run-local-release-automation.sh
- sh -n scripts/install-local-release-cron.sh
- node scripts/release-automation-status.js --json
- sh scripts/install-local-release-cron.sh --dry-run 30
