### PR TITLE
Set native version watch to JST 09:00

### DIFF
--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: "@latest"
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "0 0 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
Adjust the scheduled upstream check to run at 09:00 JST (00:00 UTC), matching the requested CI/CD timing before the 09:30 JST local follow-up.