### PR TITLE
Add Claude native 2.1.126 metadata

### DIFF
--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.base_branch || 'dev' }}
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -117,13 +117,19 @@ jobs:
           EOF
           )"
           base="${{ github.event.inputs.base_branch || 'dev' }}"
-          existing_pr="$(gh pr list --head "${branch}" --base "${base}" --state open --json url --jq '.[0].url // ""')"
+          existing_pr="$(gh pr list --repo bash0816/ClaudeCode-Termux --head "${branch}" --base "${base}" --state open --json url --jq '.[0].url // ""')"
           if [ -n "${existing_pr}" ]; then
             echo "Existing PR: ${existing_pr}"
             exit 0
           fi
-          gh pr create \
+          if gh pr create \
+            --repo bash0816/ClaudeCode-Termux \
             --base "${base}" \
             --head "${branch}" \
             --title "${title}" \
-            --body "${body}"
+            --body "${body}"; then
+            echo "Created candidate PR for ${branch}"
+          else
+            echo "PR create failed for ${branch}; continue with local gh fallback" >&2
+            exit 0
+          fi

--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -12,7 +12,7 @@ on:
         required: false
         default: "dev"
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "0 0 * * *"
 
 permissions:
   contents: write
@@ -64,35 +64,19 @@ jobs:
           version="${{ steps.version.outputs.version }}"
           workdir="${RUNNER_TEMP}/claude-${version}-native-poc"
           WORKDIR="${workdir}" node scripts/termux-prepare-claude-native-version.js "@${version}" --json > "${workdir}.json"
-          node - <<'NODE' "${version}" "${workdir}.json"
-          const fs = require('fs');
-          const version = process.argv[2];
-          const offsetFile = process.argv[3];
-          const offsets = JSON.parse(fs.readFileSync(offsetFile, 'utf8'));
-
-          const versionEntry = {
-            wrapper_spec: `@anthropic-ai/claude-code@${version}`,
-            native_spec: `@anthropic-ai/claude-code-linux-arm64@${version}`,
-            entry_js_offset: offsets.entry_js_offset,
-            entry_end_offset: offsets.entry_end_offset,
-            status: 'offset_discovered'
-          };
-
-          for (const configFile of [
-            'config/claude-native-audited-versions.json',
-            'packages/claude-code/config/claude-native-audited-versions.json'
-          ]) {
-            const config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
-            config.versions[version] = versionEntry;
-            fs.writeFileSync(configFile, JSON.stringify(config, null, 2) + '\\n');
-          }
-
-          const packageFile = 'packages/claude-code/package.json';
-          const pkg = JSON.parse(fs.readFileSync(packageFile, 'utf8'));
-          pkg.version = version;
-          fs.writeFileSync(packageFile, JSON.stringify(pkg, null, 2) + '\\n');
-          NODE
+          node scripts/add-candidate-metadata.js "${version}" "${workdir}.json" > "${workdir}.update.json"
+          node -e 'for (const file of ["config/claude-native-audited-versions.json","packages/claude-code/config/claude-native-audited-versions.json","packages/claude-code/package.json"]) JSON.parse(require("fs").readFileSync(file,"utf8"));'
           node scripts/update-release-manifest.js
+
+      - name: Candidate metadata diagnostics
+        if: steps.existing.outputs.exists == 'false' && always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          workdir="${RUNNER_TEMP}/claude-${version}-native-poc"
+          test -f "${workdir}.json" && cat "${workdir}.json" || true
+          test -f "${workdir}.update.json" && cat "${workdir}.update.json" || true
 
       - name: Commit candidate metadata
         id: candidate

--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -92,7 +92,7 @@ jobs:
           git checkout -B "${branch}"
           git add config/claude-native-audited-versions.json config/claude-termux-release-manifest.json packages/claude-code/config/claude-native-audited-versions.json packages/claude-code/config/claude-termux-release-manifest.json packages/claude-code/package.json
           git commit -m "Add Claude native ${version} offset metadata"
-          git push -u origin "${branch}" --force-with-lease
+          git push -u origin "${branch}" --force
 
       - name: Open native candidate pull request
         if: steps.existing.outputs.exists == 'false'

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -34,6 +34,13 @@
       "entry_js_offset": 232194756,
       "entry_end_offset": 246144430,
       "status": "termux_verified"
+    },
+    "2.1.126": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.126",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.126",
+      "entry_js_offset": 232535252,
+      "entry_end_offset": 246515761,
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.123",
-  "latest_candidate_version": "2.1.123",
+  "latest_candidate_version": "2.1.126",
   "previous_stable_version": "2.1.122",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/docs/20260502_candidate-intake-failure-design-review.md
+++ b/docs/20260502_candidate-intake-failure-design-review.md
@@ -25,6 +25,8 @@
 - 修正後の `workflow_dispatch version=2.1.126` では metadata 更新と candidate branch push までは成功した
 - 同 run は `gh pr create` で失敗した
 - failure message は `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)` だった
+- その後の再実行では `Commit candidate metadata` が remote `automation/native-claude-2.1.126` への `--force-with-lease` push で失敗した
+- failure message は `stale info` だった
 
 ## 推測
 
@@ -33,6 +35,8 @@
 - 原因切り分けのためには、workflow 内の inline mutation を専用 script に寄せて、更新後 JSON を即検証する方が安全
 - candidate intake の後段 failure は metadata 更新ではなく、GitHub Actions の PR 作成権限に寄っている
 - 今回の通し実行を止めないためには、candidate branch push を CI/CD の成功条件に含め、PR 作成は local `gh` fallback を許容する方が現実的
+- 再実行 failure は candidate automation branch の lease 競合に寄っている
+- candidate automation branch は human branch ではないため、同一 version の再実行では `--force` 上書きに寄せる方が実運用に合う
 
 ## STEP 2 設計判断
 
@@ -49,6 +53,7 @@
   - candidate branch push 成功
   とし、PR 作成は best-effort に落とす
 - PR 作成に失敗した場合は local `gh pr create` を手動 fallback とする
+- candidate automation branch は再実行時の上書きを許容し、push は `--force-with-lease` ではなく `--force` にする
 - candidate intake 成功後は既存 gate に従い
   - Termux verification
   - verified promotion
@@ -77,6 +82,9 @@
   - workflow は diagnostics を残して success で終える
   - candidate branch は維持
   - local `gh pr create` で次段へ進める
+- candidate branch push が `stale info` で失敗:
+  - automation branch の再実行衝突とみなし、workflow 実装を `--force` 上書きに修正する
+  - human branch への影響は無い
 - candidate PR 作成後に Termux verification 失敗:
   - candidate PR は close
   - target version は `offset_discovered` のまま据え置き

--- a/docs/20260502_candidate-intake-failure-design-review.md
+++ b/docs/20260502_candidate-intake-failure-design-review.md
@@ -22,12 +22,17 @@
   - inline metadata 追記
   - `update-release-manifest.js`
   を実行した再現では成功した
+- 修正後の `workflow_dispatch version=2.1.126` では metadata 更新と candidate branch push までは成功した
+- 同 run は `gh pr create` で失敗した
+- failure message は `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)` だった
 
 ## 推測
 
 - failure は `2.1.126` package 自体ではなく、workflow 内の candidate metadata 更新経路の脆さに寄っている可能性が高い
 - inline Node script と `update-release-manifest.js` の間に、JSON file 汚染または branch/checkout 条件差がある
 - 原因切り分けのためには、workflow 内の inline mutation を専用 script に寄せて、更新後 JSON を即検証する方が安全
+- candidate intake の後段 failure は metadata 更新ではなく、GitHub Actions の PR 作成権限に寄っている
+- 今回の通し実行を止めないためには、candidate branch push を CI/CD の成功条件に含め、PR 作成は local `gh` fallback を許容する方が現実的
 
 ## STEP 2 設計判断
 
@@ -39,6 +44,11 @@
 - `update-release-manifest.js` の前に JSON parse check を入れる
 - failure 時はどの file が壊れているか分かるよう、diagnostic を増やす
 - 今回は schedule を待たず、`workflow_dispatch version=2.1.126` で candidate intake を手動実行する
+- candidate intake workflow の成功条件は
+  - metadata 更新成功
+  - candidate branch push 成功
+  とし、PR 作成は best-effort に落とす
+- PR 作成に失敗した場合は local `gh pr create` を手動 fallback とする
 - candidate intake 成功後は既存 gate に従い
   - Termux verification
   - verified promotion
@@ -61,8 +71,12 @@
 ## Stop / Rollback
 
 - candidate intake failure:
-  - workflow は branch/PR を作らず停止
+  - metadata 更新または branch push に失敗した場合のみ workflow failure とする
   - local repo 側は feature branch にのみ修正を残す
+- candidate branch push 成功後に PR 作成だけ失敗:
+  - workflow は diagnostics を残して success で終える
+  - candidate branch は維持
+  - local `gh pr create` で次段へ進める
 - candidate PR 作成後に Termux verification 失敗:
   - candidate PR は close
   - target version は `offset_discovered` のまま据え置き
@@ -84,6 +98,7 @@
 - `node scripts/update-release-manifest.js`
 - root/package config の JSON parse check
 - `npm pack --dry-run ./packages/claude-code`
-- `Claude Native Version Watch` の `workflow_dispatch version=2.1.126` で candidate branch/PR が作成されること
+- `Claude Native Version Watch` の `workflow_dispatch version=2.1.126` で candidate branch が作成されること
+- GitHub Actions から PR が作れない場合、local `gh pr create` fallback で candidate PR を起こせること
 - `2.1.126` の verified promotion / publish / legacy sync まで到達できること
 - 各 stop 条件で後段 workflow が起動しないこと

--- a/docs/20260502_candidate-intake-failure-design-review.md
+++ b/docs/20260502_candidate-intake-failure-design-review.md
@@ -1,0 +1,89 @@
+# Candidate Intake Failure Design Review
+
+## STEP 1 計画固定
+
+- 対象: `ClaudeCode-Termux` の `Claude Native Version Watch`
+- 目的: upstream `2.1.126` の candidate intake が CI/CD で失敗している問題を修正する
+- 範囲:
+  - failure 再現条件の固定
+  - candidate metadata 更新フローの hardening
+  - workflow の failure diagnostics 強化
+  - 今回に限り `workflow_dispatch` を用いた `2.1.126` の candidate intake から release までの手動実行
+
+## 事実
+
+- 2026-05-02 時点で upstream npm `latest` は `2.1.126`
+- `Claude Native Version Watch` の schedule run は直近 2 回とも失敗している
+- 失敗 run の log では `@anthropic-ai/claude-code-linux-arm64@2.1.126` の取得までは成功している
+- 失敗箇所は `node scripts/update-release-manifest.js`
+- error は `SyntaxError: Unexpected non-whitespace character after JSON ...`
+- ローカルで `origin/main` 相当 worktree に対し、workflow と同じ
+  - `termux-prepare-claude-native-version.js`
+  - inline metadata 追記
+  - `update-release-manifest.js`
+  を実行した再現では成功した
+
+## 推測
+
+- failure は `2.1.126` package 自体ではなく、workflow 内の candidate metadata 更新経路の脆さに寄っている可能性が高い
+- inline Node script と `update-release-manifest.js` の間に、JSON file 汚染または branch/checkout 条件差がある
+- 原因切り分けのためには、workflow 内の inline mutation を専用 script に寄せて、更新後 JSON を即検証する方が安全
+
+## STEP 2 設計判断
+
+- workflow 内の inline Node mutation をやめ、専用 script に切り出す
+- 専用 script は次を 1 つの責務で行う
+  - target version の metadata 追加
+  - package version 更新
+  - root/package config 整合性検証
+- `update-release-manifest.js` の前に JSON parse check を入れる
+- failure 時はどの file が壊れているか分かるよう、diagnostic を増やす
+- 今回は schedule を待たず、`workflow_dispatch version=2.1.126` で candidate intake を手動実行する
+- candidate intake 成功後は既存 gate に従い
+  - Termux verification
+  - verified promotion
+  - canonical publish
+  - legacy sync
+  まで進める
+
+### 新規 script interface
+
+- 追加候補: `scripts/add-candidate-metadata.js`
+- 想定呼び出し:
+  - `node scripts/add-candidate-metadata.js 2.1.126 offsets.json`
+- 入力:
+  - arg1: version
+  - arg2: `termux-prepare-claude-native-version.js --json` の結果 file
+- 出力:
+  - success 時は更新した file path と version を JSON で stdout
+  - failure 時はどの file の parse/update に失敗したかを stderr に出し、exit 1
+
+## Stop / Rollback
+
+- candidate intake failure:
+  - workflow は branch/PR を作らず停止
+  - local repo 側は feature branch にのみ修正を残す
+- candidate PR 作成後に Termux verification 失敗:
+  - candidate PR は close
+  - target version は `offset_discovered` のまま据え置き
+  - audited promotion / publish / legacy sync は開始しない
+- verified promotion failure:
+  - `feature -> dev` で停止
+  - `dev/staging/main` には上げない
+- canonical publish failure:
+  - `main` metadata は残す
+  - legacy sync は開始しない
+- legacy sync failure:
+  - canonical publish 済みは維持
+  - legacy repo の sync PR/branch だけ再実行対象にする
+
+## STEP 4 再現条件・テスト観点
+
+- `node scripts/termux-prepare-claude-native-version.js @2.1.126 --json`
+- candidate metadata 追加 script の単体実行
+- `node scripts/update-release-manifest.js`
+- root/package config の JSON parse check
+- `npm pack --dry-run ./packages/claude-code`
+- `Claude Native Version Watch` の `workflow_dispatch version=2.1.126` で candidate branch/PR が作成されること
+- `2.1.126` の verified promotion / publish / legacy sync まで到達できること
+- 各 stop 条件で後段 workflow が起動しないこと

--- a/docs/20260502_candidate-intake-failure-implementation-plan.md
+++ b/docs/20260502_candidate-intake-failure-implementation-plan.md
@@ -1,0 +1,48 @@
+# Candidate Intake Failure Implementation Plan
+
+## STEP 3 実装プラン
+
+1. candidate metadata 更新用の専用 script を追加する
+   - name: `scripts/add-candidate-metadata.js`
+   - interface: `node scripts/add-candidate-metadata.js <version> <offset-json-file>`
+2. workflow から inline Node mutation を除去し、新 script を呼ぶ
+3. 新 script で
+   - root config 更新
+   - package config 更新
+   - package version 更新
+   - JSON parse check
+   - root/package version key 一致確認
+   を行う
+4. workflow に diagnostic step を追加し、failure 時に
+   - target version
+   - updated file paths
+   - JSON parse check
+   を残す
+5. local で `2.1.126` candidate intake を再現し、script / manifest 更新が通ることを確認する
+6. `workflow_dispatch` で `2.1.126` candidate intake を再実行する
+7. candidate branch/PR 作成後、Termux verification を通して `2.1.126` を verified promotion する
+8. canonical `dev -> staging -> main` と canonical publish を進める
+9. legacy sync 完了まで確認する
+
+## 停止条件
+
+- `add-candidate-metadata.js` が失敗したら candidate intake workflow は exit 1 で停止する
+- candidate PR 作成後に Termux verification が失敗したら、その版では verified promotion を実行しない
+- canonical publish が失敗したら legacy sync を dispatch しない
+- legacy sync が失敗したら canonical publish は rollback せず、legacy sync だけ再試行対象にする
+
+## 対象ファイル
+
+- `.github/workflows/claude-native-version-watch.yml`
+- `scripts/update-release-manifest.js`
+- `scripts/termux-prepare-claude-native-version.js`
+- `scripts/add-candidate-metadata.js`
+
+## 完了条件
+
+- local 再現で `2.1.126` candidate metadata 更新が通る
+- `Claude Native Version Watch` の `workflow_dispatch` が success
+- `automation/native-claude-2.1.126` branch か candidate PR が作成される
+- canonical package `@bash0816/claude-code` が `2.1.126` になる
+- legacy metadata が `2.1.126` へ同期される
+- stop 条件で後段 workflow が進まないことを確認できる

--- a/docs/20260502_candidate-intake-failure-implementation-plan.md
+++ b/docs/20260502_candidate-intake-failure-implementation-plan.md
@@ -19,17 +19,19 @@
    - JSON parse check
    を残す
 5. workflow の PR 作成 step を best-effort にし、failure 時は diagnostics を残して継続できるようにする
-6. local で `2.1.126` candidate intake を再現し、script / manifest 更新が通ることを確認する
-7. `workflow_dispatch` で `2.1.126` candidate intake を再実行する
-8. candidate branch は CI/CD で必ず作成し、PR が無ければ local `gh pr create` で補完する
-9. candidate branch/PR 作成後、Termux verification を通して `2.1.126` を verified promotion する
-10. canonical `dev -> staging -> main` と canonical publish を進める
-11. legacy sync 完了まで確認する
+6. candidate automation branch push は再実行を許容し、`--force-with-lease` ではなく `--force` を使う
+7. local で `2.1.126` candidate intake を再現し、script / manifest 更新が通ることを確認する
+8. `workflow_dispatch` で `2.1.126` candidate intake を再実行する
+9. candidate branch は CI/CD で必ず作成し、PR が無ければ local `gh pr create` で補完する
+10. candidate branch/PR 作成後、Termux verification を通して `2.1.126` を verified promotion する
+11. canonical `dev -> staging -> main` と canonical publish を進める
+12. legacy sync 完了まで確認する
 
 ## 停止条件
 
 - `add-candidate-metadata.js` または branch push が失敗したら candidate intake workflow は exit 1 で停止する
 - PR 作成だけ失敗した場合は candidate branch を残し、local `gh` fallback へ切り替える
+- candidate automation branch への再実行衝突は `--force` 上書きで吸収する
 - candidate PR 作成後に Termux verification が失敗したら、その版では verified promotion を実行しない
 - canonical publish が失敗したら legacy sync を dispatch しない
 - legacy sync が失敗したら canonical publish は rollback せず、legacy sync だけ再試行対象にする

--- a/docs/20260502_candidate-intake-failure-implementation-plan.md
+++ b/docs/20260502_candidate-intake-failure-implementation-plan.md
@@ -18,15 +18,18 @@
    - updated file paths
    - JSON parse check
    を残す
-5. local で `2.1.126` candidate intake を再現し、script / manifest 更新が通ることを確認する
-6. `workflow_dispatch` で `2.1.126` candidate intake を再実行する
-7. candidate branch/PR 作成後、Termux verification を通して `2.1.126` を verified promotion する
-8. canonical `dev -> staging -> main` と canonical publish を進める
-9. legacy sync 完了まで確認する
+5. workflow の PR 作成 step を best-effort にし、failure 時は diagnostics を残して継続できるようにする
+6. local で `2.1.126` candidate intake を再現し、script / manifest 更新が通ることを確認する
+7. `workflow_dispatch` で `2.1.126` candidate intake を再実行する
+8. candidate branch は CI/CD で必ず作成し、PR が無ければ local `gh pr create` で補完する
+9. candidate branch/PR 作成後、Termux verification を通して `2.1.126` を verified promotion する
+10. canonical `dev -> staging -> main` と canonical publish を進める
+11. legacy sync 完了まで確認する
 
 ## 停止条件
 
-- `add-candidate-metadata.js` が失敗したら candidate intake workflow は exit 1 で停止する
+- `add-candidate-metadata.js` または branch push が失敗したら candidate intake workflow は exit 1 で停止する
+- PR 作成だけ失敗した場合は candidate branch を残し、local `gh` fallback へ切り替える
 - candidate PR 作成後に Termux verification が失敗したら、その版では verified promotion を実行しない
 - canonical publish が失敗したら legacy sync を dispatch しない
 - legacy sync が失敗したら canonical publish は rollback せず、legacy sync だけ再試行対象にする
@@ -42,7 +45,8 @@
 
 - local 再現で `2.1.126` candidate metadata 更新が通る
 - `Claude Native Version Watch` の `workflow_dispatch` が success
-- `automation/native-claude-2.1.126` branch か candidate PR が作成される
+- `automation/native-claude-2.1.126` branch が作成される
+- candidate PR は workflow か local fallback のどちらかで作成される
 - canonical package `@bash0816/claude-code` が `2.1.126` になる
 - legacy metadata が `2.1.126` へ同期される
 - stop 条件で後段 workflow が進まないことを確認できる

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -34,6 +34,13 @@
       "entry_js_offset": 232194756,
       "entry_end_offset": 246144430,
       "status": "termux_verified"
+    },
+    "2.1.126": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.126",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.126",
+      "entry_js_offset": 232535252,
+      "entry_end_offset": 246515761,
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.123",
-  "latest_candidate_version": "2.1.123",
+  "latest_candidate_version": "2.1.126",
   "previous_stable_version": "2.1.122",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.123",
+  "version": "2.1.126",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {

--- a/scripts/add-candidate-metadata.js
+++ b/scripts/add-candidate-metadata.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const version = process.argv[2];
+const offsetFile = process.argv[3];
+
+if (!version || !offsetFile) {
+  console.error('usage: node scripts/add-candidate-metadata.js <version> <offset-json-file>');
+  process.exit(1);
+}
+
+const repoRoot = path.resolve(__dirname, '..');
+const configFiles = [
+  path.join(repoRoot, 'config', 'claude-native-audited-versions.json'),
+  path.join(repoRoot, 'packages', 'claude-code', 'config', 'claude-native-audited-versions.json'),
+];
+const packageFile = path.join(repoRoot, 'packages', 'claude-code', 'package.json');
+
+function loadJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    throw new Error(`failed to parse JSON: ${path.relative(repoRoot, file)}: ${error.message}`);
+  }
+}
+
+function assertSameVersionKeys() {
+  const rootConfig = loadJson(configFiles[0]);
+  const packageConfig = loadJson(configFiles[1]);
+  const rootKeys = Object.keys(rootConfig.versions).sort();
+  const packageKeys = Object.keys(packageConfig.versions).sort();
+  if (JSON.stringify(rootKeys) !== JSON.stringify(packageKeys)) {
+    throw new Error('root/package version metadata mismatch after update');
+  }
+}
+
+function main() {
+  const offsets = loadJson(path.resolve(offsetFile));
+  const versionEntry = {
+    wrapper_spec: `@anthropic-ai/claude-code@${version}`,
+    native_spec: `@anthropic-ai/claude-code-linux-arm64@${version}`,
+    entry_js_offset: offsets.entry_js_offset,
+    entry_end_offset: offsets.entry_end_offset,
+    status: 'offset_discovered',
+  };
+
+  const updatedFiles = [];
+
+  for (const file of configFiles) {
+    const config = loadJson(file);
+    config.versions[version] = versionEntry;
+    fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\n');
+    updatedFiles.push(path.relative(repoRoot, file));
+  }
+
+  const pkg = loadJson(packageFile);
+  pkg.version = version;
+  fs.writeFileSync(packageFile, JSON.stringify(pkg, null, 2) + '\n');
+  updatedFiles.push(path.relative(repoRoot, packageFile));
+
+  assertSameVersionKeys();
+
+  process.stdout.write(JSON.stringify({
+    version,
+    updated_files: updatedFiles,
+  }, null, 2) + '\n');
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
Automated native metadata candidate for Claude Code 2.1.126.

Review required before merge:
- Confirm install on Termux.
- Confirm launch and auth status.
- Confirm `claude update` behavior.
- Confirm npm package dry-run or publish flow.

If upstream package structure changed, close this PR and update the native preparation script.