### PR TITLE
Move native version watch to JST 04:00

### DIFF
--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -12,7 +12,7 @@ on:
         required: false
         default: "dev"
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 19 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
Adjust the scheduled native version watch to run at JST 04:00.

This changes the GitHub Actions cron from UTC 00:00 to UTC 19:00 so it aligns with the requested JST schedule.

Local Termux cron has already been updated separately to JST 04:30.