### PR TITLE
Add PR fallback runbook

### DIFF
--- a/docs/20260502_pr-fallback-runbook-design-review.md
+++ b/docs/20260502_pr-fallback-runbook-design-review.md
@@ -1,0 +1,73 @@
+# PR Fallback Runbook Design Review
+
+## STEP 1 計画固定
+
+- 対象: `ClaudeCode-Termux` / `CluadeCode-Termux` release automation の `createPullRequest` fallback
+- 目的: GitHub Actions が PR を自動作成できない場合でも、同じ手順で安全に後段を継続できる runbook を固定する
+- 範囲:
+  - canonical candidate PR
+  - canonical promotion PR
+  - canonical `dev -> staging`
+  - canonical `staging -> main`
+  - legacy sync PR
+  - legacy `dev -> staging`
+  - legacy `staging -> main`
+
+## 事実
+
+- 今回の `2.1.126` では、GitHub Actions からの PR 作成がすべて同じ失敗で止まった
+- failure message は `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)` だった
+- 一方で各 workflow は branch push や publish までは成功していた
+- local `gh pr create` fallback に切り替えることで、canonical / legacy ともに `main` まで進められた
+- 今回の fallback は以下で実証済み
+  - canonical candidate PR `#10`
+  - canonical promotion PR `#12`
+  - canonical `dev -> staging` PR `#13`
+  - canonical `staging -> main` PR `#14`
+  - legacy sync PR `#15`
+  - legacy `dev -> staging` PR `#16`
+  - legacy `staging -> main` PR `#17`
+
+## 推測
+
+- 失敗は release logic ではなく GitHub token 権限に寄っている
+- そのため、当面の安定運用では「workflow は branch 生成まで」「PR 作成は local fallback 可」と切り分けるのが合理的
+- token 再設計より先に runbook を固定した方が、次回運用コストを即座に下げられる
+
+## STEP 2 設計判断
+
+### 基本方針
+
+- GitHub Actions は branch / publish / metadata 更新までを正とする
+- PR 作成が失敗した場合は local `gh pr create` を正規 fallback とする
+- fallback は branch が実在し、前段 workflow が success のときだけ実行する
+- fallback 後の merge は従来どおり `feature/* -> dev -> staging -> main` を守る
+
+### runbook に含める項目
+
+1. どの workflow failure が fallback 対象か
+2. branch が生成済みかの確認方法
+3. 実行すべき `gh pr create` コマンド
+4. merge 後に確認すべき follow-up workflow
+5. local fallback では進めない停止条件
+
+### 停止条件
+
+- branch push が失敗している場合は PR fallback に進まない
+- local verification が未完了の version は promotion PR を作らない
+- canonical publish が未完了なら legacy sync に進まない
+- `main` へ直接 push しない
+
+## STEP 4 再現条件・テスト観点
+
+- `createPullRequest` failure 後に branch が remote に存在すること
+- local fallback PR 作成後に merge できること
+- merge 後の `Npm Package` / `Publish Audited Release` / legacy sync が続行すること
+- canonical / legacy の `main` manifest が期待 version に揃うこと
+- npm 公開 version が canonical 側で期待 version に上がること
+
+## 設計結論
+
+- `createPullRequest` failure は token 起因の運用上の問題として扱う
+- 当面の最適解は別 token 導入より先に runbook 化
+- runbook は今回実証した `2.1.126` の実コマンドを基に固定する

--- a/docs/20260502_pr-fallback-runbook-implementation-plan.md
+++ b/docs/20260502_pr-fallback-runbook-implementation-plan.md
@@ -1,0 +1,36 @@
+# PR Fallback Runbook Implementation Plan
+
+## STEP 3 実装プラン
+
+1. `docs/` に PR fallback 専用 runbook を追加する
+2. canonical / legacy の 7 パターンをそれぞれ明記する
+3. 各パターンに以下を固定する
+   - 事前条件
+   - branch existence check
+   - `gh pr create` 例
+   - merge 後の確認対象 workflow
+4. `2.1.126` で実際に使った PR 番号と run 種別を記録する
+5. 「いつ fallback してはいけないか」の停止条件も併記する
+6. 最後に reviewer に runbook の妥当性を確認して閉じる
+
+## 対象ファイル
+
+- `docs/20260502_pr-fallback-runbook-design-review.md`
+- `docs/20260502_pr-fallback-runbook-implementation-plan.md`
+- `docs/20260502_pr-fallback-runbook.md`
+
+## runbook で固定する fallback 一覧
+
+1. canonical candidate PR
+2. canonical promotion PR
+3. canonical `dev -> staging`
+4. canonical `staging -> main`
+5. legacy sync PR
+6. legacy `dev -> staging`
+7. legacy `staging -> main`
+
+## 完了条件
+
+- 次回 `createPullRequest` failure 時に、runbook だけで同じ復旧手順を辿れる
+- canonical / legacy のどこで local fallback するかが曖昧でない
+- branch 未生成や verification 未完了など、fallback 禁止条件が明記されている

--- a/docs/20260502_pr-fallback-runbook.md
+++ b/docs/20260502_pr-fallback-runbook.md
@@ -1,0 +1,181 @@
+# PR Fallback Runbook
+
+## 目的
+
+GitHub Actions が `createPullRequest` 権限不足で止まったとき、branch 生成済みの後段を local `gh pr create` で継続する。
+
+## 前提
+
+- `gh auth status` で対象 repo に操作できること
+- branch push 自体は workflow success か log で確認済みであること
+- `main` へ直接 push しないこと
+
+## 共通確認
+
+1. 対象 workflow run が branch 生成まで成功している
+2. remote branch が存在する
+3. 前段 gate を満たしている
+
+例:
+
+```sh
+git -C /data/data/com.termux/files/home/ClaudeCode-Termux ls-remote --heads origin automation/native-claude-2.1.126
+git -C /data/data/com.termux/files/home/ClaudeCode-Termux ls-remote --heads origin automation/promote-claude-2.1.126
+```
+
+## 1. Canonical Candidate PR
+
+条件:
+- candidate intake workflow success
+- `automation/native-claude-<version>` branch が存在
+
+実行:
+
+```sh
+gh pr create \
+  --repo bash0816/ClaudeCode-Termux \
+  --base dev \
+  --head automation/native-claude-2.1.126 \
+  --title "Add Claude native 2.1.126 metadata" \
+  --body "Automated native metadata candidate for Claude Code 2.1.126."
+```
+
+次:
+- local verification shell を実行する
+
+## 2. Canonical Promotion PR
+
+条件:
+- local verification 成功
+- promotion workflow success
+- `automation/promote-claude-<version>` branch が存在
+
+実行:
+
+```sh
+gh pr create \
+  --repo bash0816/ClaudeCode-Termux \
+  --base dev \
+  --head automation/promote-claude-2.1.126 \
+  --title "Promote Claude native 2.1.126" \
+  --body "Promotion candidate for Claude Code 2.1.126."
+```
+
+次:
+- merge 後に `Npm Package` on `dev` を確認する
+
+## 3. Canonical `dev -> staging`
+
+条件:
+- `Npm Package` on `dev` success
+
+実行:
+
+```sh
+gh pr create \
+  --repo bash0816/ClaudeCode-Termux \
+  --base staging \
+  --head dev \
+  --title "Promote canonical release flow to staging" \
+  --body "Automated dev to staging promotion for canonical release metadata."
+```
+
+次:
+- merge 後に `Npm Package` on `staging` を確認する
+
+## 4. Canonical `staging -> main`
+
+条件:
+- `Npm Package` on `staging` success
+
+実行:
+
+```sh
+gh pr create \
+  --repo bash0816/ClaudeCode-Termux \
+  --base main \
+  --head staging \
+  --title "Release canonical audited version to main" \
+  --body "Automated staging to main promotion for canonical audited metadata."
+```
+
+補足:
+- `main` 側 hotfix と `staging` 側 release flow が競合する場合は、先に `staging` に `main` を取り込んでから merge する
+
+次:
+- merge 後に `Publish Audited Release` と `Npm Package` workflow_dispatch publish を確認する
+
+## 5. Legacy Sync PR
+
+条件:
+- canonical publish success
+- `automation/legacy-sync-claude-<version>` branch が存在
+
+実行:
+
+```sh
+gh pr create \
+  --repo bash0816/CluadeCode-Termux \
+  --base dev \
+  --head automation/legacy-sync-claude-2.1.126 \
+  --title "Sync legacy metadata to Claude 2.1.126" \
+  --body "Automated sync from canonical ClaudeCode-Termux main."
+```
+
+次:
+- merge 後に `Npm Package` on `dev` を確認する
+
+## 6. Legacy `dev -> staging`
+
+条件:
+- legacy `Npm Package` on `dev` success
+
+実行:
+
+```sh
+gh pr create \
+  --repo bash0816/CluadeCode-Termux \
+  --base staging \
+  --head dev \
+  --title "Promote legacy release flow to staging" \
+  --body "Automated legacy dev to staging promotion for synced metadata."
+```
+
+次:
+- merge 後に legacy `Npm Package` on `staging` を確認する
+
+## 7. Legacy `staging -> main`
+
+条件:
+- legacy `Npm Package` on `staging` success
+
+実行:
+
+```sh
+gh pr create \
+  --repo bash0816/CluadeCode-Termux \
+  --base main \
+  --head staging \
+  --title "Release legacy synced version to main" \
+  --body "Automated legacy staging to main promotion for synced metadata."
+```
+
+次:
+- merge 後に legacy `main` manifest が同期されたことを確認する
+
+## やってはいけないこと
+
+- branch push 未確認で PR だけ作らない
+- local verification 未完了で promotion PR を作らない
+- canonical publish 前に legacy sync を始めない
+- `main` へ直接 push しない
+
+## 2.1.126 実績
+
+- canonical candidate PR: `#10`
+- canonical promotion PR: `#12`
+- canonical `dev -> staging`: `#13`
+- canonical `staging -> main`: `#14`
+- legacy sync PR: `#15`
+- legacy `dev -> staging`: `#16`
+- legacy `staging -> main`: `#17`


### PR DESCRIPTION
Add reviewed design, implementation plan, and runbook docs for local PR fallback when GitHub Actions cannot create pull requests.