### PR TITLE
Automate canonical README version guidance sync

### DIFF
--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -67,6 +67,7 @@ jobs:
           node scripts/add-candidate-metadata.js "${version}" "${workdir}.json" > "${workdir}.update.json"
           node -e 'for (const file of ["config/claude-native-audited-versions.json","packages/claude-code/config/claude-native-audited-versions.json","packages/claude-code/package.json"]) JSON.parse(require("fs").readFileSync(file,"utf8"));'
           node scripts/update-release-manifest.js
+          node scripts/update-readme-version-guidance.js
 
       - name: Candidate metadata diagnostics
         if: steps.existing.outputs.exists == 'false' && always()
@@ -90,7 +91,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "${branch}"
-          git add config/claude-native-audited-versions.json config/claude-termux-release-manifest.json packages/claude-code/config/claude-native-audited-versions.json packages/claude-code/config/claude-termux-release-manifest.json packages/claude-code/package.json
+          git add README.md config/claude-native-audited-versions.json config/claude-termux-release-manifest.json packages/claude-code/README.md packages/claude-code/config/claude-native-audited-versions.json packages/claude-code/config/claude-termux-release-manifest.json packages/claude-code/package.json
           git commit -m "Add Claude native ${version} offset metadata"
           git push -u origin "${branch}" --force
 

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -3,7 +3,9 @@ name: Npm Package
 on:
   pull_request:
     paths:
+      - "README.md"
       - "packages/claude-code/**"
+      - "packages/claude-code/README.md"
       - "config/**"
       - "scripts/**"
       - ".github/workflows/npm-package.yml"
@@ -13,7 +15,9 @@ on:
       - dev
       - staging
     paths:
+      - "README.md"
       - "packages/claude-code/**"
+      - "packages/claude-code/README.md"
       - "config/**"
       - "scripts/**"
       - ".github/workflows/npm-package.yml"
@@ -79,6 +83,7 @@ jobs:
           node --check lib/check-updates.js
           node --check lib/postinstall.js
           node --check lib/preinstall.js
+          node --check ../../scripts/update-readme-version-guidance.js
           node --check ../../scripts/update-release-manifest.js
           node --check ../../scripts/promote-verified-version.js
 
@@ -107,7 +112,8 @@ jobs:
         run: |
           set -euo pipefail
           node ../../scripts/update-release-manifest.js
-          git diff --exit-code -- config/claude-native-audited-versions.json config/claude-termux-release-manifest.json
+          node ../../scripts/update-readme-version-guidance.js
+          git diff --exit-code -- ../../README.md README.md config/claude-native-audited-versions.json config/claude-termux-release-manifest.json
 
       - name: Pack dry run
         run: npm pack --dry-run

--- a/.github/workflows/promote-verified-candidate.yml
+++ b/.github/workflows/promote-verified-candidate.yml
@@ -35,6 +35,7 @@ jobs:
           version="${{ inputs.version }}"
           node scripts/promote-verified-version.js "${version}"
           node scripts/update-release-manifest.js
+          node scripts/update-readme-version-guidance.js
 
       - name: Commit promotion branch
         id: branch
@@ -47,7 +48,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "${branch}"
-          git add config/claude-native-audited-versions.json config/claude-termux-release-manifest.json packages/claude-code/config/claude-native-audited-versions.json packages/claude-code/config/claude-termux-release-manifest.json packages/claude-code/package.json
+          git add README.md config/claude-native-audited-versions.json config/claude-termux-release-manifest.json packages/claude-code/README.md packages/claude-code/config/claude-native-audited-versions.json packages/claude-code/config/claude-termux-release-manifest.json packages/claude-code/package.json
           git commit -m "Promote Claude native ${version} to termux verified"
           git push -u origin "${branch}" --force-with-lease
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ Only versions registered in the audited metadata can run.
 
 監査済み metadata に登録済みの version だけを実行します。
 
-Current audited versions in this repository:
-
-この repository に現在入っている監査済み version:
-
 - `2.1.118`
 - `2.1.119`
 - `2.1.121`

--- a/docs/20260502_readme-sync-automation-design-review.md
+++ b/docs/20260502_readme-sync-automation-design-review.md
@@ -1,0 +1,124 @@
+# 2026-05-02 README Sync Automation Design Review
+
+## STEP 2
+
+## 背景
+
+- canonical README は audited version を固定列挙しており、`2.1.123` と `2.1.126` 追加時に stale になった
+- legacy README も bridge package version と synced metadata version がずれやすい
+- 今回は手修正で直したが、今後も metadata / manifest 更新のたびに同じズレが起こり得る
+
+## 事実
+
+- canonical の source of truth は次
+  - `config/claude-native-audited-versions.json`
+  - `config/claude-termux-release-manifest.json`
+- legacy の source of truth は次
+  - `packages/cluade-code/package.json`
+  - `config/claude-termux-release-manifest.json`
+  - `config/claude-native-audited-versions.json`
+- canonical 側では candidate intake と verified promotion の workflow が metadata / manifest を commit している
+- legacy 側では canonical sync workflow が metadata / manifest を commit している
+
+## 問題
+
+- README の version 節が source of truth から独立している
+- workflow は metadata / manifest 更新を自動化しているが、README 更新は人手依存
+- その結果、release は正しく進んでも user-facing docs が古くなる
+
+## 方針候補
+
+### 案 A: README の version 節を script で再生成し、workflow で必ず実行する
+
+- 利点
+  - source of truth と docs を機械的に同期できる
+  - candidate intake / promotion / legacy sync の既存 commit に README 変更を同梱できる
+  - `npm-package.yml` で drift check をかけられる
+- 欠点
+  - README 構造に依存する置換 script が必要
+
+### 案 B: README から固定 version 列挙を外し、metadata file 参照だけにする
+
+- 利点
+  - stale 化しにくい
+  - automation 実装が軽い
+- 欠点
+  - end-user README として不親切
+  - install / expected output の quick example が消える
+
+## 判断
+
+- 採用は `案 A`
+- fixed list は残すが、README 上でも `quick examples` とし、source of truth は metadata / manifest と明記する
+- legacy README は package version と synced metadata version を分離して出す
+
+## 設計
+
+### canonical
+
+- script が次を metadata / manifest から再生成する
+  - root `README.md`
+  - `packages/claude-code/README.md`
+- user-facing canonical version list は `status === "termux_verified"` の version だけを使う
+- `offset_discovered` の candidate は README の audited examples / supported list / override examples に出さない
+- 再生成対象
+  - specific audited version examples
+  - supported version list
+  - expected output example
+  - development override examples
+
+### legacy
+
+- legacy repo に別 script を置く
+- script が次を package metadata / manifest から再生成する
+  - root `README.md`
+  - `packages/cluade-code/README.md`
+- legacy sync 対象 version も `status === "termux_verified"` 前提で扱う
+- 再生成対象
+  - final bridge package version
+  - default native version
+  - latest audited version in synced metadata
+  - canonical install guidance
+  - expected output example
+
+## CI/CD 組み込み点
+
+### canonical
+
+- `.github/workflows/claude-native-version-watch.yml`
+  - `update-release-manifest.js` 後に README sync script を実行
+  - commit 対象に README を追加
+- `.github/workflows/promote-verified-candidate.yml`
+  - `update-release-manifest.js` 後に README sync script を実行
+  - commit 対象に README を追加
+- `.github/workflows/npm-package.yml`
+  - syntax check に README sync script の `node --check`
+  - verify step で script 実行後 `git diff --exit-code` を取り、README drift を fail にする
+  - path filter に root `README.md` と `packages/claude-code/README.md` を追加する
+
+### legacy
+
+- `.github/workflows/sync-canonical-metadata.yml`
+  - metadata / manifest mirror 後に README sync script を実行
+  - commit 対象に README を追加
+- legacy `npm-package.yml` にも同じ drift check を必須で入れる
+- path filter に root `README.md` と `packages/cluade-code/README.md` を追加する
+
+## 期待結果
+
+- metadata / manifest を更新する automation が、そのまま README の version 節も同期する
+- user-facing README が audited state とずれない
+- 手修正忘れは CI で検出できる
+
+## リスク
+
+- README の見出しや文言を大きく変えると script の置換条件が壊れる
+- そのため section 単位の明示 marker か、見出し境界ベースの安定した置換が必要
+- 置換失敗時は hard fail にして silent drift を避ける
+
+## Go 条件
+
+- canonical / legacy の source of truth が明確
+- workflow に組み込む位置が明確
+- drift check が publish 前に効く
+- legacy bridge package と synced metadata version の表現が混同されない

--- a/docs/20260502_readme-sync-automation-implementation-plan.md
+++ b/docs/20260502_readme-sync-automation-implementation-plan.md
@@ -1,0 +1,69 @@
+# 2026-05-02 README Sync Automation Implementation Plan
+
+## STEP 3
+
+## 対象
+
+- canonical repo
+  - `scripts/update-readme-version-guidance.js`
+  - `.github/workflows/claude-native-version-watch.yml`
+  - `.github/workflows/promote-verified-candidate.yml`
+  - `.github/workflows/npm-package.yml`
+- legacy repo
+  - `scripts/update-readme-version-guidance.js`
+  - `.github/workflows/sync-canonical-metadata.yml`
+  - `.github/workflows/npm-package.yml`
+
+## 実装順
+
+1. canonical 用 README sync script を追加する
+2. legacy 用 README sync script を追加する
+3. canonical workflows に script 実行と commit 対象追加を入れる
+4. legacy sync workflow に script 実行と commit 対象追加を入れる
+5. canonical npm-package verify に README drift check を入れる
+6. legacy npm-package verify に README drift check を入れる
+7. 実行ログと diff を確認する
+
+## script 要件
+
+### canonical script
+
+- `status === "termux_verified"` の audited versions だけを semver sort して出す
+- root / package README を同時更新する
+- 置換対象は見出し単位で限定する
+- expected output は `manifest.latest_audited_version` を example に使う
+- candidate の `offset_discovered` version は README に出さない
+- 置換 marker か安定した section 境界を使い、置換失敗時は hard fail にする
+
+### legacy script
+
+- package version は `packages/cluade-code/package.json` から読む
+- default native / latest audited は legacy manifest から読む
+- canonical 側から同期される version は `termux_verified` 前提とする
+- canonical package 名と repository URL は固定値でよい
+- root / package README を同時更新する
+- 置換失敗時は hard fail にする
+
+## validation
+
+- `node --check scripts/update-readme-version-guidance.js`
+- `node scripts/update-readme-version-guidance.js`
+- `git diff -- README.md packages/claude-code/README.md`
+- legacy 側でも同等確認
+- workflow 側は `git diff --exit-code` で drift fail を確認する
+- canonical / legacy の `npm-package.yml` path filter に root/package README を追加する
+
+## review 観点
+
+- 置換範囲が広すぎないか
+- metadata / manifest を読んだ値と README 表示が一致するか
+- legacy で package version と native version が混同されていないか
+- candidate / promotion / sync のどの経路でも README が更新されるか
+- README-only 修正でも drift check workflow が起動するか
+
+## 完了条件
+
+- canonical metadata 更新 workflow が README 同期込みで commit する
+- legacy sync workflow が README 同期込みで commit する
+- npm-package verify が README drift を検出できる
+- 手修正無しで README stale を再現しなくなる

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -92,7 +92,7 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 
 - Only audited versions in `config/claude-native-audited-versions.json` can run.
 - `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。
-- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, and `2.1.126` are included in the package metadata.
+- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126` are included in the package metadata.
 - `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。

--- a/scripts/update-readme-version-guidance.js
+++ b/scripts/update-readme-version-guidance.js
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const rootConfigFile = path.join(repoRoot, 'config', 'claude-native-audited-versions.json');
+const packageConfigFile = path.join(repoRoot, 'packages', 'claude-code', 'config', 'claude-native-audited-versions.json');
+const manifestFile = path.join(repoRoot, 'config', 'claude-termux-release-manifest.json');
+const rootReadmeFile = path.join(repoRoot, 'README.md');
+const packageReadmeFile = path.join(repoRoot, 'packages', 'claude-code', 'README.md');
+
+function compareVersions(a, b) {
+  const aParts = String(a).split('.').map(Number);
+  const bParts = String(b).split('.').map(Number);
+  const len = Math.max(aParts.length, bParts.length);
+  for (let index = 0; index < len; index += 1) {
+    const diff = (aParts[index] || 0) - (bParts[index] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function loadJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function assertSameVersions(rootConfig, packageConfig) {
+  const rootVersions = Object.keys(rootConfig.versions).sort(compareVersions);
+  const packageVersions = Object.keys(packageConfig.versions).sort(compareVersions);
+  if (JSON.stringify(rootVersions) !== JSON.stringify(packageVersions)) {
+    throw new Error('root/package version metadata mismatch');
+  }
+}
+
+function replaceBetween(content, start, end, replacement, fileLabel) {
+  const startIndex = content.indexOf(start);
+  if (startIndex === -1) {
+    throw new Error(`start anchor not found in ${fileLabel}`);
+  }
+  const searchIndex = startIndex + start.length;
+  const endIndex = content.indexOf(end, searchIndex);
+  if (endIndex === -1) {
+    throw new Error(`end anchor not found in ${fileLabel}`);
+  }
+  return content.slice(0, searchIndex) + replacement + content.slice(endIndex);
+}
+
+function replaceToEnd(content, start, replacement, fileLabel) {
+  const startIndex = content.indexOf(start);
+  if (startIndex === -1) {
+    throw new Error(`start anchor not found in ${fileLabel}`);
+  }
+  const searchIndex = startIndex + start.length;
+  return content.slice(0, searchIndex) + replacement;
+}
+
+function formatShellBlock(lines) {
+  return `\`\`\`sh\n${lines.join('\n')}\n\`\`\``;
+}
+
+function formatTextBlock(lines) {
+  return `\`\`\`text\n${lines.join('\n')}\n\`\`\``;
+}
+
+function renderVersionBullets(versions) {
+  return versions.map(version => `- \`${version}\``).join('\n');
+}
+
+function renderInstallCommands(versions) {
+  return versions.map(version => `npm install -g @bash0816/claude-code@${version}`);
+}
+
+function renderOverrideCommands(versions) {
+  return versions.map(version => `CLAUDE_TERMUX_CLAUDE_VERSION=${version} claude --version`);
+}
+
+function updateRootReadme(content, versions, latestAudited) {
+  const installBlock = [
+    'Current quick examples:',
+    '',
+    '現在の quick example:',
+    '',
+    formatShellBlock(renderInstallCommands(versions)),
+    '',
+  ].join('\n');
+
+  content = replaceBetween(
+    content,
+    'Install a specific audited version.\n\n監査済みの固定 version を入れる場合:\n\n',
+    '\n## Update / 更新\n',
+    installBlock,
+    'README.md install examples'
+  );
+
+  const supportedBlock = [
+    renderVersionBullets(versions),
+    '',
+    'The source of truth is the metadata files below.',
+    '',
+    '正式な source of truth は、下の metadata files です。',
+    '',
+  ].join('\n');
+
+  content = replaceBetween(
+    content,
+    'Only versions registered in the audited metadata can run.\n\n監査済み metadata に登録済みの version だけを実行します。\n\n',
+    '\nMetadata files:\n',
+    supportedBlock,
+    'README.md supported versions'
+  );
+
+  const expectedBlock = [
+    formatTextBlock(['<installed_audited_version> (Claude Code)']),
+    '',
+    'Example:',
+    '',
+    '例:',
+    '',
+    formatTextBlock([`${latestAudited} (Claude Code)`]),
+    '',
+  ].join('\n');
+
+  content = replaceBetween(
+    content,
+    'Expected version output:\n\n期待値:\n\n',
+    '\n## Package Development / package 開発\n',
+    expectedBlock,
+    'README.md expected output'
+  );
+
+  const overrideBlock = [
+    formatShellBlock(renderOverrideCommands(versions)),
+    '',
+  ].join('\n');
+
+  content = replaceBetween(
+    content,
+    'For development and verification, the launcher can switch between audited versions from the same package.\n\n開発・検証時のみ、同じ package から監査済み version を切り替えられます。\n\n',
+    '\n## Native Version Metadata / native metadata\n',
+    overrideBlock,
+    'README.md override examples'
+  );
+
+  return content;
+}
+
+function updatePackageReadme(content, versions) {
+  const installBlock = [
+    'Current quick examples:',
+    '',
+    '現在の quick example:',
+    '',
+    formatShellBlock(renderInstallCommands(versions)),
+    '',
+  ].join('\n');
+
+  content = replaceBetween(
+    content,
+    'Specific audited versions:\n\n監査済みの固定 version:\n\n',
+    '\nDevelopment override:\n',
+    installBlock,
+    'packages/claude-code/README.md install examples'
+  );
+
+  const overrideBlock = [
+    formatShellBlock(renderOverrideCommands(versions)),
+    '',
+  ].join('\n');
+
+  content = replaceBetween(
+    content,
+    'Development override:\n\n開発・検証用 override:\n\n',
+    '\n## Update / 更新\n',
+    overrideBlock,
+    'packages/claude-code/README.md override examples'
+  );
+
+  const policySection = [
+    '- Only audited versions in `config/claude-native-audited-versions.json` can run.',
+    '- `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。',
+    `- ${versions.map(version => `\`${version}\``).join(', ')} are included in the package metadata.`,
+    `- ${versions.map(version => `\`${version}\``).join('、')} を package metadata に含めています。`,
+    '- The metadata file is the source of truth for the currently audited set.',
+    '- 現在の監査済み version 集合の source of truth は metadata file です。',
+    '- Native artifacts are cached under `${HOME}/.claude-termux-native-package`.',
+    '- native artifact は `${HOME}/.claude-termux-native-package` に cache します。',
+    '- If native preparation fails, the command exits with an error.',
+    '- native preparation に失敗した場合、command は error で終了します。',
+    '',
+  ].join('\n');
+
+  content = replaceToEnd(
+    content,
+    '## Policy / 方針\n\n',
+    policySection,
+    'packages/claude-code/README.md policy'
+  );
+
+  return content;
+}
+
+function main() {
+  const rootConfig = loadJson(rootConfigFile);
+  const packageConfig = loadJson(packageConfigFile);
+  const manifest = loadJson(manifestFile);
+
+  assertSameVersions(rootConfig, packageConfig);
+
+  const verifiedVersions = Object.keys(rootConfig.versions)
+    .filter(version => rootConfig.versions[version].status === 'termux_verified')
+    .sort(compareVersions);
+
+  if (verifiedVersions.length === 0) {
+    throw new Error('no termux_verified versions found');
+  }
+
+  if (!verifiedVersions.includes(manifest.latest_audited_version)) {
+    throw new Error('manifest latest audited version is not termux_verified');
+  }
+
+  const rootReadme = fs.readFileSync(rootReadmeFile, 'utf8');
+  const packageReadme = fs.readFileSync(packageReadmeFile, 'utf8');
+
+  fs.writeFileSync(rootReadmeFile, updateRootReadme(rootReadme, verifiedVersions, manifest.latest_audited_version));
+  fs.writeFileSync(packageReadmeFile, updatePackageReadme(packageReadme, verifiedVersions));
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a README sync script driven by audited metadata and manifest
- run the script from candidate/promotion workflows and npm drift checks
- document the design and implementation plan for the automation