### PR TITLE
Add Claude native 2.1.128 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ npm install -g @bash0816/claude-code@2.1.121
 npm install -g @bash0816/claude-code@2.1.122
 npm install -g @bash0816/claude-code@2.1.123
 npm install -g @bash0816/claude-code@2.1.126
+npm install -g @bash0816/claude-code@2.1.128
 ```
 
 ## Update / 更新
@@ -67,6 +68,7 @@ Only versions registered in the audited metadata can run.
 - `2.1.122`
 - `2.1.123`
 - `2.1.126`
+- `2.1.128`
 
 The source of truth is the metadata files below.
 
@@ -104,7 +106,7 @@ Example:
 例:
 
 ```text
-2.1.126 (Claude Code)
+2.1.128 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -47,7 +47,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.128",
       "entry_js_offset": 233148036,
       "entry_end_offset": 247200101,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -41,6 +41,13 @@
       "entry_js_offset": 232535252,
       "entry_end_offset": 246515761,
       "status": "termux_verified"
+    },
+    "2.1.128": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.128",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.128",
+      "entry_js_offset": 233148036,
+      "entry_end_offset": 247200101,
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.126",
+  "latest_audited_version": "2.1.128",
   "latest_candidate_version": "2.1.128",
-  "previous_stable_version": "2.1.123",
+  "previous_stable_version": "2.1.126",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.126",
-  "latest_candidate_version": "2.1.126",
+  "latest_candidate_version": "2.1.128",
   "previous_stable_version": "2.1.123",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -49,6 +49,7 @@ npm install -g @bash0816/claude-code@2.1.121
 npm install -g @bash0816/claude-code@2.1.122
 npm install -g @bash0816/claude-code@2.1.123
 npm install -g @bash0816/claude-code@2.1.126
+npm install -g @bash0816/claude-code@2.1.128
 ```
 
 ## Update / 更新
@@ -73,8 +74,8 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 
 - Only audited versions in `config/claude-native-audited-versions.json` can run.
 - `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。
-- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126` are included in the package metadata.
-- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126` を package metadata に含めています。
+- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128` are included in the package metadata.
+- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。
 - Native artifacts are cached under `${HOME}/.claude-termux-native-package`.

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -77,5 +77,7 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 - `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。
+- Native artifacts are cached under `${HOME}/.claude-termux-native-package`.
+- native artifact は `${HOME}/.claude-termux-native-package` に cache します。
 - If native preparation fails, the command exits with an error.
 - native preparation に失敗した場合、command は error で終了します。

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -47,7 +47,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.128",
       "entry_js_offset": 233148036,
       "entry_end_offset": 247200101,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -41,6 +41,13 @@
       "entry_js_offset": 232535252,
       "entry_end_offset": 246515761,
       "status": "termux_verified"
+    },
+    "2.1.128": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.128",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.128",
+      "entry_js_offset": 233148036,
+      "entry_end_offset": 247200101,
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.126",
+  "latest_audited_version": "2.1.128",
   "latest_candidate_version": "2.1.128",
-  "previous_stable_version": "2.1.123",
+  "previous_stable_version": "2.1.126",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.126",
-  "latest_candidate_version": "2.1.126",
+  "latest_candidate_version": "2.1.128",
   "previous_stable_version": "2.1.123",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.126",
+  "version": "2.1.128",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Automated native metadata candidate for Claude Code 2.1.128.

Review required before merge:
- Confirm install on Termux.
- Confirm launch and auth status.
- Confirm claude update behavior.
- Confirm npm package dry-run or publish flow.
