### PR TITLE
Fix local candidate detection for cron follow-up

### DIFF
--- a/docs/20260506_fix-local-candidate-detection-design-review.md
+++ b/docs/20260506_fix-local-candidate-detection-design-review.md
@@ -1,0 +1,41 @@
+# 2026-05-06 Fix Local Candidate Detection Design Review
+
+## Reviewed Target
+
+- `20260506_fix-local-candidate-detection-plan.md`
+
+## Design Question
+
+`release-automation-status.js` の candidate branch 検出を、
+exact ref path から prefix match へ直す設計は妥当か。
+
+## Proposed Answer
+
+Go.
+
+## Rationale
+
+1. branch 自体は存在している
+   - `origin/automation/native-claude-2.1.128`
+2. state lock も candidate 側を塞いでいない
+   - lock は `2.1.126`
+3. local result が `2.1.126` に戻るのは、
+   branch detection failure から `origin/dev` manifest fallback している説明と整合する
+4. したがって、まず直すべきは
+   - remote branch listing
+   - version extraction
+   であり、local shell そのものではない
+
+## Boundary
+
+- state file schema は変えない
+- candidate branch naming は変えない
+- local cron 時刻も変えない
+- `run-local-release-automation.sh` 本体は変えない
+
+## Expected Outcome
+
+- `release-automation-status.js --json`
+  - `latest_candidate_version = 2.1.128`
+  - `needs_verification = true`
+- local shell が `no_action` ではなく verification path へ進める

--- a/docs/20260506_fix-local-candidate-detection-implementation-plan.md
+++ b/docs/20260506_fix-local-candidate-detection-implementation-plan.md
@@ -1,0 +1,33 @@
+# 2026-05-06 Fix Local Candidate Detection Implementation Plan
+
+## Objective
+
+`scripts/release-automation-status.js` の remote candidate branch 検出を修正する。
+
+## Steps
+
+1. `listRemoteBranches(prefix)` を prefix match へ直す
+2. `loadCandidateVersion()` が
+   - `automation/native-claude-<version>`
+   を拾えることを確認する
+3. `node --check scripts/release-automation-status.js`
+4. `git fetch --prune origin` 後に
+   - `node scripts/release-automation-status.js --json`
+   を実行
+5. `GPT-5.5` reviewer で STEP 8/9
+6. その後
+   - `sh scripts/run-local-release-automation.sh --dry-run`
+   - 必要なら本実行
+   まで進む
+
+## Success Criteria
+
+- `latest_candidate_version = 2.1.128`
+- `needs_verification = true`
+- `local_verification_locked = false`
+
+## Non-Goals
+
+- state file schema 変更
+- cron 時刻変更
+- verification logic 自体の変更

--- a/docs/20260506_fix-local-candidate-detection-plan.md
+++ b/docs/20260506_fix-local-candidate-detection-plan.md
@@ -1,0 +1,43 @@
+# 2026-05-06 Fix Local Candidate Detection Plan
+
+## Goal
+
+`release-automation-status.js` が remote candidate branch を正しく検出し、
+local cron / shell が `needs_verification=true` へ進めるようにする。
+
+## Facts
+
+- current upstream candidate branch exists:
+  - `origin/automation/native-claude-2.1.128`
+- current `release-automation-status.js --json`
+  - `latest_audited_version = 2.1.126`
+  - `latest_candidate_version = 2.1.126`
+  - `needs_verification = false`
+- current state file lock is only for:
+  - `2.1.126`
+- `git for-each-ref --format='%(refname:short)' refs/remotes/origin/automation/native-claude-`
+  - returns nothing
+- `git for-each-ref --format='%(refname:short)' refs/remotes/origin/automation`
+  - returns `origin/automation/native-claude-2.1.128`
+
+## Working Hypothesis
+
+`listRemoteBranches(prefix)` が exact ref path を見ていて、
+prefix match をしていない。
+
+そのため:
+- `origin/automation/native-claude-2.1.128`
+が存在しても
+- `loadCandidateVersion()` が空を返し
+- fallback で `origin/dev` manifest の `2.1.126` に戻っている。
+
+## Expected Fix
+
+1. remote branch listing を prefix match に直す
+2. `automation/native-claude-*` を candidate source として拾う
+3. `2.1.128 > 2.1.126` を正しく判定する
+4. state lock は candidate version 単位で引き続き評価する
+5. result が
+   - `latest_candidate_version = 2.1.128`
+   - `needs_verification = true`
+   になることを確認する

--- a/docs/20260506_fix-local-candidate-detection-test-scope.md
+++ b/docs/20260506_fix-local-candidate-detection-test-scope.md
@@ -1,0 +1,26 @@
+# 2026-05-06 Fix Local Candidate Detection Test Scope
+
+## STEP 4
+
+## Repro
+
+- remote branch exists:
+  - `origin/automation/native-claude-2.1.128`
+- current status script still returns:
+  - `latest_candidate_version = 2.1.126`
+  - `needs_verification = false`
+
+## Test Points
+
+1. branch listing returns prefixed branches
+2. version extraction still returns bare version
+3. candidate version is compared against `latest_audited_version`
+4. stale state lock for another version does not suppress `2.1.128`
+5. fallback to `origin/dev` manifest only happens when no newer branch exists
+
+## Minimal Commands
+
+- `node --check scripts/release-automation-status.js`
+- `git fetch --prune origin`
+- `node scripts/release-automation-status.js --json`
+- `sh scripts/run-local-release-automation.sh --dry-run`

--- a/scripts/release-automation-status.js
+++ b/scripts/release-automation-status.js
@@ -61,14 +61,16 @@ function loadManifestFromGit(cwd, ref) {
 }
 
 function listRemoteBranches(prefix) {
-  const result = run('git', ['for-each-ref', '--format=%(refname:short)', `refs/remotes/origin/${prefix}`]);
+  const result = run('git', ['for-each-ref', '--format=%(refname:short)', 'refs/remotes/origin']);
   return result.stdout ? result.stdout.split('\n').map(line => line.trim()).filter(Boolean) : [];
 }
 
 function extractVersionFromBranch(branch, prefix) {
   const marker = `origin/${prefix}`;
   if (!branch.startsWith(marker)) return '';
-  return branch.slice(marker.length);
+  const tail = branch.slice(marker.length);
+  if (!/^\d+(?:\.\d+){1,2}(?:[-+][0-9A-Za-z.-]+)?$/.test(tail)) return '';
+  return tail;
 }
 
 function maxVersion(versions) {


### PR DESCRIPTION
## Summary
- fix release-automation-status remote candidate branch detection
- let local cron follow-up see automation/native-claude-2.1.128
- add plan/design/implementation/test-scope docs for the local automation fix

## Verification
- node --check scripts/release-automation-status.js
- node scripts/release-automation-status.js --json
- sh scripts/run-local-release-automation.sh --dry-run (explained by main lag before promotion)
- GPT-5.5 review: Go
