### PR TITLE
Fix local candidate verification handoff

### DIFF
--- a/docs/20260506_fix-local-verification-handoff-design-review.md
+++ b/docs/20260506_fix-local-verification-handoff-design-review.md
@@ -1,0 +1,46 @@
+# 2026-05-06 Fix Local Verification Handoff Design Review
+
+## Reviewed Target
+
+- `20260506_fix-local-verification-handoff-plan.md`
+
+## Design Question
+
+local verification automation を、
+- `main` clone 実体ではなく candidate branch 実体で検証し
+- success 後は removed workflow dispatch ではなく
+- same candidate branch を `termux_verified` に更新して push/PR へ進める
+設計は妥当か。
+
+## Proposed Answer
+
+Go.
+
+## Rationale
+
+1. current failure は verification logic ではなく repo checkout の問題。
+   - candidate branch はある
+   - status detection も直った
+   - だが verification repo 実体が `main` のまま
+2. removed workflow への dispatch は現在の public 実体と整合しない。
+3. candidate branch 自体は `dev` ベースで作られている。
+   - その branch 上で `offset_discovered -> termux_verified` に上げれば
+   - 既存 PR をそのまま review 導線として使える
+4. publish / legacy sync をここでやらない設計は安全。
+
+## Boundary
+
+- local automation shell only
+- no change to cron schedule
+- no change to state schema
+- no direct merge
+- no npm publish
+- if candidate branch is missing:
+  - hard stop
+  - no stale-main verification
+
+## Expected Outcome
+
+- local actual run on `2.1.128` no longer fails at `Unsupported audited Claude Code version`
+- success時は candidate branch が verified content に更新される
+- open PR があればその PR が更新される

--- a/docs/20260506_fix-local-verification-handoff-implementation-plan.md
+++ b/docs/20260506_fix-local-verification-handoff-implementation-plan.md
@@ -1,0 +1,41 @@
+# 2026-05-06 Fix Local Verification Handoff Implementation Plan
+
+## Objective
+
+`scripts/run-local-release-automation.sh` を current public shape に合わせる。
+
+## Steps
+
+1. derive `candidate_branch=automation/native-claude-<version>`
+2. after clone/fetch, if branch exists:
+   - checkout candidate branch in `run_dir/repo`
+3. if branch does not exist:
+   - stop before verification
+   - emit failure/no-verification result
+4. update prompt facts:
+   - repository checkout branch
+   - candidate branch name
+5. replace success action from removed workflow dispatch to:
+   - `node scripts/promote-verified-version.js <version>`
+   - `node scripts/update-release-manifest.js`
+   - `node scripts/update-readme-version-guidance.js`
+   - commit
+   - push `--force-with-lease`
+   - create PR best-effort only if none exists
+6. keep JSON schema unchanged
+   - `promotion_dispatched=true` means branch/PR handoff prepared
+7. notes must state that `promotion_dispatched` means local branch/PR handoff prepared, not workflow dispatch
+8. dry-run
+9. actual run
+
+## Success Criteria
+
+- dry-run prompt references candidate branch checkout
+- actual run verifies against candidate metadata instead of stale `main`
+- removed workflow name is no longer referenced
+
+## Non-Goals
+
+- merge automation
+- npm publish automation
+- legacy sync automation

--- a/docs/20260506_fix-local-verification-handoff-plan.md
+++ b/docs/20260506_fix-local-verification-handoff-plan.md
@@ -1,0 +1,50 @@
+# 2026-05-06 Fix Local Verification Handoff Plan
+
+## Goal
+
+`run-local-release-automation.sh` を、
+- candidate branch を checkout した実体で検証し
+- 成功時は同じ candidate branch を `termux_verified` へ更新して
+- 既存 PR を進める
+形へ直す。
+
+## Facts
+
+- current dry-run after status fix:
+  - `latest_candidate_version = 2.1.128`
+  - `needs_verification = true`
+- current actual local run failed because:
+  - cloned repo manifest still had `latest_candidate_version = 2.1.126`
+  - `config/claude-native-audited-versions.json` did not include `2.1.128`
+  - `prepare-native.js 2.1.128` failed with `Unsupported audited Claude Code version: 2.1.128`
+- current prompt still asks Codex to run:
+  - `gh workflow run promote-verified-candidate.yml ...`
+- but current public repo no longer has:
+  - `.github/workflows/promote-verified-candidate.yml`
+
+## Root Cause
+
+1. local automation clones `main` and keeps that checkout for verification
+2. verification therefore runs against stale metadata instead of candidate branch content
+3. post-verification path still targets a removed workflow
+
+## Expected Fix
+
+1. after reading `candidate_version`, derive:
+   - `candidate_branch = automation/native-claude-<version>`
+2. if that remote branch exists:
+   - checkout `origin/<candidate_branch>` in the cloned repo before Codex verification
+3. if that remote branch does not exist:
+   - hard stop
+   - do not verify against stale `main`
+   - write a failure/no-verification result instead
+4. update prompt so that success path is:
+   - `node scripts/promote-verified-version.js <version>`
+   - `node scripts/update-release-manifest.js`
+   - `node scripts/update-readme-version-guidance.js`
+   - commit
+   - `git push --force-with-lease origin <candidate_branch>`
+   - if no open PR exists for head `<candidate_branch>` base `dev`, create one best-effort
+5. do not merge
+6. do not publish
+7. do not sync legacy

--- a/docs/20260506_fix-local-verification-handoff-test-scope.md
+++ b/docs/20260506_fix-local-verification-handoff-test-scope.md
@@ -1,0 +1,27 @@
+# 2026-05-06 Fix Local Verification Handoff Test Scope
+
+## STEP 4
+
+## Repro
+
+- status is now correct:
+  - `latest_candidate_version = 2.1.128`
+  - `needs_verification = true`
+- actual local run still fails because repo checkout remains at stale `main`
+- prompt still references removed `promote-verified-candidate.yml`
+
+## Test Points
+
+1. candidate branch existence check
+2. candidate branch checkout in cloned repo
+3. prompt no longer references removed workflow
+4. success path references local promote script + manifest/readme sync
+5. push target is the candidate branch itself
+6. PR create is best-effort and only when no open PR exists
+7. JSON schema remains unchanged
+
+## Minimal Commands
+
+- `sh -n scripts/run-local-release-automation.sh`
+- `sh scripts/run-local-release-automation.sh --dry-run`
+- actual `sh scripts/run-local-release-automation.sh`

--- a/scripts/run-local-release-automation.sh
+++ b/scripts/run-local-release-automation.sh
@@ -12,7 +12,6 @@ STATE_FILE="${CLAUDE_TERMUX_STATE_FILE:-${STATE_ROOT}/canonical-release-state.js
 SCHEMA_FILE="${REPO_ROOT}/scripts/codex-release-automation-output.schema.json"
 SOURCE_REF="${CLAUDE_TERMUX_AUTOMATION_SOURCE_REF:-main}"
 BASE_BRANCH="${CLAUDE_TERMUX_AUTOMATION_BASE_BRANCH:-dev}"
-WORKFLOW_REF="${CLAUDE_TERMUX_AUTOMATION_WORKFLOW_REF:-main}"
 DRY_RUN=0
 
 if [ "${1:-}" = "--dry-run" ]; then
@@ -48,6 +47,8 @@ needs_publish=$(read_json_field "${status_json}" needs_publish)
 needs_legacy_sync=$(read_json_field "${status_json}" needs_legacy_sync)
 local_verification_locked=$(read_json_field "${status_json}" local_verification_locked)
 local_state_file=$(read_json_field "${status_json}" local_state_file)
+candidate_branch="automation/native-claude-${candidate_version}"
+candidate_remote_ref="origin/${candidate_branch}"
 
 write_state() {
   version="$1"
@@ -93,7 +94,7 @@ if [ "${needs_verification}" != "true" ]; then
   elif [ "${needs_publish}" = "true" ]; then
     note="canonical publish pending in GitHub Actions follow-up"
   elif [ "${needs_legacy_sync}" = "true" ]; then
-    note="legacy sync pending in GitHub Actions follow-up"
+    note="follow-up pending in GitHub Actions"
   fi
   cat > "${result_json}" <<EOF
 {"mode":"no_action","candidate_version":null,"audited_version":"${audited_version}","published_version":"${published_version}","verification_passed":false,"promotion_dispatched":false,"publish_dispatched":false,"notes":["${note}","state_file=${local_state_file}"]} 
@@ -102,25 +103,43 @@ EOF
   exit 0
 fi
 
+if ! git -C "${run_dir}/repo" show-ref --verify --quiet "refs/remotes/${candidate_remote_ref}"; then
+  cat > "${result_json}" <<EOF
+{"mode":"no_action","candidate_version":"${candidate_version}","audited_version":"${audited_version}","published_version":"${published_version}","verification_passed":false,"promotion_dispatched":false,"publish_dispatched":false,"notes":["candidate branch missing; stopped before verification","branch=${candidate_branch}","state_file=${local_state_file}"]} 
+EOF
+  cat "${result_json}"
+  exit 0
+fi
+
+git -C "${run_dir}/repo" checkout -B "${candidate_branch}" "${candidate_remote_ref}" >/dev/null 2>&1
+
 prompt_file="${log_dir}/prompt.txt"
 cat > "${prompt_file}" <<EOF
 Use skill cluade-termux-release-cicd.
 
 Facts:
 - Repository: ${run_dir}/repo
+- Repository checked out at candidate branch: ${candidate_branch}
 - Latest audited version on main manifest: ${audited_version}
 - Latest candidate version on main manifest: ${candidate_version}
 - Promotion target base branch: ${BASE_BRANCH}
-- Promotion workflow ref: ${WORKFLOW_REF}
 - Local state file: ${local_state_file}
 
 Task:
-1. Verify candidate version ${candidate_version} on this Termux environment.
+1. Verify candidate version ${candidate_version} on checked out candidate branch ${candidate_branch}.
 2. Run prepare-native, claude --version, claude auth status, claude update --dry-run, and temp-prefix npm install checks through the wrapper path.
 3. If and only if all checks pass, run:
-   gh workflow run promote-verified-candidate.yml --repo bash0816/ClaudeCode-Termux --ref ${WORKFLOW_REF} -f version=${candidate_version} -f base_branch=${BASE_BRANCH}
-4. Do not push code changes.
+   node scripts/promote-verified-version.js ${candidate_version}
+   node scripts/update-release-manifest.js
+   node scripts/update-readme-version-guidance.js
+   git add README.md config/claude-native-audited-versions.json config/claude-termux-release-manifest.json packages/claude-code/README.md packages/claude-code/config/claude-native-audited-versions.json packages/claude-code/config/claude-termux-release-manifest.json packages/claude-code/package.json
+   git commit -m "Promote native Claude ${candidate_version}"
+   git push --force-with-lease origin ${candidate_branch}
+   if no open PR exists, gh pr create --repo bash0816/ClaudeCode-Termux --base ${BASE_BRANCH} --head ${candidate_branch}
+4. Do not use the removed workflow or any publish/legacy sync path.
 5. Final answer must be JSON matching the provided schema.
+6. Set promotion_dispatched=true only when the local branch / PR handoff is prepared.
+7. If promotion_dispatched=true, notes must explicitly say it means local branch/PR handoff prepared and not GitHub workflow dispatch.
 EOF
 
 if [ "${DRY_RUN}" -eq 1 ]; then


### PR DESCRIPTION
## Summary
- verify candidates on the candidate branch instead of stale main
- hard-stop when the candidate branch is missing
- replace removed workflow dispatch with local promotion handoff steps

## Verification
- sh -n scripts/run-local-release-automation.sh
- sh scripts/run-local-release-automation.sh --dry-run
- sh scripts/run-local-release-automation.sh
