### PR TITLE
Add Bun stringWidth polyfill for 2.1.128

### DIFF
--- a/docs/20260506_fix-bun-stringwidth-design-review.md
+++ b/docs/20260506_fix-bun-stringwidth-design-review.md
@@ -1,0 +1,47 @@
+# 2026-05-06 Fix Bun stringWidth Design Review
+
+## Target
+
+`packages/claude-code/lib/termux-run-claude-native.sh`
+
+## Proposed Design
+
+- wrapper が注入する fake Bun object を最小拡張する
+- 追加対象は `Bun.stringWidth`
+- 実装は Node 上で完結する純関数にする
+- 既存の `version` 偽装と同じスコープで only runtime injection とする
+- extracted bundle や native binary は書き換えない
+
+## Why This Layer
+
+- 再現箇所は extracted bundle 実行時の fake Bun 不足
+- candidate metadata や offset mismatch ではない
+- bundle 書換えより wrapper 層の方が update 追従性が高い
+- future bundle が同系の `Bun.stringWidth` 利用を増やしても吸収しやすい
+
+## Polyfill Shape
+
+最小要件:
+- `Bun.stringWidth(input, options)` 形式で呼べる
+- string coercion を行う
+- crash せず number を返す
+
+第一候補:
+- `Intl.Segmenter` ベースの grapheme count を width として返す
+- `options` は受け取るが、まずは `ambiguousIsNarrow` などを無視してもよい
+
+理由:
+- 今回の gate は width 精度ではなく runtime crash 解消
+- `auth status` や CLI 表示では、この近似でも regression risk は低い
+- dependency 追加なしで済む
+
+## Risks
+
+- East Asian width や ANSI escape 幅の完全再現ではない
+- 今後 `Bun.stringWidth` の厳密意味に依存する UI では表示ズレの可能性がある
+- ただし現時点では `crash > slight width drift` の優先度
+
+## Rollback
+
+- wrapper への polyfill 追加 1 箇所を revert すれば戻せる
+- bundle / cache / metadata を汚さないので rollback は容易

--- a/docs/20260506_fix-bun-stringwidth-implementation-plan.md
+++ b/docs/20260506_fix-bun-stringwidth-implementation-plan.md
@@ -1,0 +1,38 @@
+# 2026-05-06 Fix Bun stringWidth Implementation Plan
+
+## STEP 3
+
+## Files
+
+- `packages/claude-code/lib/termux-run-claude-native.sh`
+- `docs/20260506_fix-bun-stringwidth-*.md`
+
+## Implementation
+
+1. Node heredoc 内に `createBunStringWidth()` を追加する
+2. `Intl.Segmenter` で grapheme 単位に数える最小 polyfill を実装する
+3. fake Bun を
+   - `version: '1.1.8'`
+   - `stringWidth: createBunStringWidth()`
+   に拡張する
+4. 既存 Bun restore path を壊さない
+
+## STEP 4 Test Points
+
+- `2.1.128 prepare-native` succeeds
+- `2.1.128 claude --version` succeeds
+- `2.1.128 claude auth status` no longer throws `Bun.stringWidth`
+- `2.1.128 claude update --dry-run` still succeeds
+- if possible, rerun local automation path for candidate branch after patch
+
+## Minimal Commands
+
+- `sh -n packages/claude-code/lib/termux-run-claude-native.sh`
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 node packages/claude-code/lib/prepare-native.js 2.1.128`
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.128 sh packages/claude-code/bin/claude --version`
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.128 sh packages/claude-code/bin/claude auth status`
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.128 sh packages/claude-code/bin/claude update --dry-run`
+
+## Stop Condition
+
+- if `auth status` moves past `Bun.stringWidth` but fails at a new candidate-specific runtime layer, stop and record the new blocker before promotion

--- a/docs/20260506_fix-bun-stringwidth-plan.md
+++ b/docs/20260506_fix-bun-stringwidth-plan.md
@@ -1,0 +1,36 @@
+# 2026-05-06 Fix Bun stringWidth Plan
+
+## Goal
+
+`2.1.128` candidate verification で `claude auth status` が `TypeError: Bun.stringWidth is not a function` で落ちる問題を、wrapper 層で吸収して再検証可能にする。
+
+## Facts
+
+- `2.1.128` candidate branch 上では以下が再現する。
+  - `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.128 sh packages/claude-code/bin/claude auth status`
+  - 結果: `TypeError: Bun.stringWidth is not a function`
+- `2.1.128` の抽出 JS には `Bun.stringWidth(q, Yi9)` の直呼びが 1 箇所ある。
+- `2.1.126` の抽出 JS にはその直呼びはなく、`typeof Bun.stringWidth === "function" ? ... : fallback` だけがある。
+- 現在の wrapper は `globalThis.Bun = { version: '1.1.8' }` しか入れていない。
+- 問題箇所は bundle 抽出後 JS の実行時であり、native binary や offset 不整合ではない。
+
+## Working Hypothesis
+
+- `2.1.128` 以降の bundle が Bun API surface を 1 段増やし、Node 上の fake Bun が不足した。
+- `auth status` 失敗はその不足 API で止まっており、最小で `Bun.stringWidth` を polyfill すれば candidate verification を再開できる可能性が高い。
+
+## Candidate Fix
+
+第一候補:
+- `packages/claude-code/lib/termux-run-claude-native.sh` の fake Bun に `stringWidth` polyfill を追加する。
+
+設計意図:
+- bundle 本体への version 固定 patch を避ける
+- fake Bun surface を拡張するだけに留める
+- 将来の近縁 Bun API surface 増加にも追従しやすくする
+
+## Out of Scope
+
+- native binary patch
+- candidate metadata の offset 再監査
+- public release 判定そのもの

--- a/docs/20260506_fix-bun-stringwidth-result.md
+++ b/docs/20260506_fix-bun-stringwidth-result.md
@@ -1,0 +1,53 @@
+# 2026-05-06 Fix Bun stringWidth Result
+
+## Repro
+
+Candidate clone:
+- `/data/data/com.termux/files/home/.codex-release-cicd/work/20260506T004224Z/repo`
+
+Failing command before patch:
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.128 sh packages/claude-code/bin/claude auth status`
+
+Observed failure:
+- `TypeError: Bun.stringWidth is not a function`
+
+## Patch
+
+- target: `packages/claude-code/lib/termux-run-claude-native.sh`
+- change: fake Bun object に `stringWidth` polyfill を追加
+- shape:
+  - `Intl.Segmenter` があれば grapheme count
+  - 無ければ `Array.from(text).length`
+
+## Verification
+
+Patched script mirrored into candidate clone for runtime validation only.
+
+- `sh -n packages/claude-code/lib/termux-run-claude-native.sh`
+  - success
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 node packages/claude-code/lib/prepare-native.js 2.1.128`
+  - success
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.128 sh packages/claude-code/bin/claude --version`
+  - expected `2.1.128 (Claude Code)`
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.128 sh packages/claude-code/bin/claude auth status`
+  - success after patch
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.128 sh packages/claude-code/bin/claude update --dry-run`
+  - success
+
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.126 sh packages/claude-code/bin/claude --version`
+  - success
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.126 sh packages/claude-code/bin/claude auth status`
+  - success
+- `env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.126 sh packages/claude-code/bin/claude update --dry-run`
+  - success
+
+## Facts
+
+- `2.1.128` extracted JS has one direct `Bun.stringWidth` call.
+- `2.1.126` extracted JS does not have that direct call and keeps fallback-only shape.
+- The wrapper-layer polyfill is sufficient to move `auth status` past the crash in the real candidate environment.
+
+## Residual Risk
+
+- width calculation is approximate, not Bun-compatible in full detail
+- display alignment drift is still possible even though runtime crash is removed

--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -73,6 +73,17 @@ function ensureEntryFile() {
   return extractedFile;
 }
 
+function stringWidth(value) {
+  const text = String(value ?? '');
+  if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
+    const segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
+    let width = 0;
+    for (const _segment of segmenter.segment(text)) width += 1;
+    return width;
+  }
+  return Array.from(text).length;
+}
+
 function createFakeRequire(realRequire) {
   const realChild = realRequire('child_process');
   function rewriteArgs(args) {
@@ -140,7 +151,7 @@ async function main() {
     process.once('uncaughtException', onAsyncError);
     process.once('unhandledRejection', onAsyncError);
     Object.defineProperty(process.versions, 'bun', { value: '1.1.8', configurable: true });
-    globalThis.Bun = { version: '1.1.8' };
+    globalThis.Bun = { version: '1.1.8', stringWidth };
     process.argv = ['node', extractedFile, ...argv];
     process.exit = code => {
       throw new RequestedExit(code);


### PR DESCRIPTION
## Summary
- add a fake Bun.stringWidth polyfill in the Termux wrapper
- fix the 2.1.128 auth status crash on candidate verification
- document the repro and validation evidence

## Verification
- sh -n packages/claude-code/lib/termux-run-claude-native.sh
- 2.1.128 prepare-native / version / auth status / update --dry-run in candidate clone
- 2.1.126 version / auth status / update --dry-run smoke checks
