### PR TITLE
Copy git identity into local automation clone

### DIFF
--- a/docs/20260506_fix-local-git-identity-design-review.md
+++ b/docs/20260506_fix-local-git-identity-design-review.md
@@ -1,0 +1,23 @@
+# 2026-05-06 Fix Local Git Identity Design Review
+
+## Target
+
+- `scripts/run-local-release-automation.sh`
+
+## Proposed Design
+
+- temp clone 作成後、source repo local config を clone local config へ移す
+- source of truth は `${REPO_ROOT}` の git local config
+- global git config には依存しない
+- commit command 自体は変えない
+
+## Why This Layer
+
+- 失敗は verification 後の temp clone handoff に限定される
+- promotion script や manifest logic ではない
+- one-shot clone local config 追加なら rollback が簡単
+
+## Rollback
+
+- clone local config 設定処理を revert すれば元に戻る
+- metadata/package/cache/state への副作用はない

--- a/docs/20260506_fix-local-git-identity-implementation-plan.md
+++ b/docs/20260506_fix-local-git-identity-implementation-plan.md
@@ -1,0 +1,23 @@
+# 2026-05-06 Fix Local Git Identity Implementation Plan
+
+## STEP 3
+
+## Implementation
+
+1. `run-local-release-automation.sh` に source repo identity read helper を追加する
+2. clone 後に `git config user.name` / `git config user.email` を local clone に設定する
+3. どちらかが空なら hard stop して identity missing を result notes に出す
+4. 値が揃っている場合のみ clone local config に設定する
+5. 既存 flow は変えず、commit path だけ安定化する
+
+## STEP 4 Test Points
+
+- dry-run path は壊れない
+- actual local automation で verification success 後に `git commit` が identity 不足で止まらない
+- temp clone で `git config --get user.name` / `user.email` が確認できる
+- candidate branch push / PR handoff まで進む
+
+## Minimal Commands
+
+- `sh -n scripts/run-local-release-automation.sh`
+- actual `sh scripts/run-local-release-automation.sh`

--- a/docs/20260506_fix-local-git-identity-plan.md
+++ b/docs/20260506_fix-local-git-identity-plan.md
@@ -1,0 +1,25 @@
+# 2026-05-06 Fix Local Git Identity Plan
+
+## Goal
+
+`run-local-release-automation.sh` の candidate verification 成功後に、temp clone で `git commit` が author identity 不足で落ちる問題を解消する。
+
+## Facts
+
+- current local automation run `20260506T030013Z` では candidate verification 自体は成功した。
+- 失敗点は success path の `git commit -m "Promote native Claude 2.1.128"`。
+- エラーは `Author identity unknown`。
+- source repo `/data/data/com.termux/files/home/ClaudeCode-Termux` には local git config がある。
+  - `user.name = Vash0001`
+  - `user.email = bash0816@gmail.com`
+- global git config には user identity が無い。
+
+## Working Hypothesis
+
+- temp clone 作成後に source repo の local identity を clone 側へコピーすれば、automation handoff の commit は通る。
+
+## Candidate Fix
+
+- `run-local-release-automation.sh` で clone/fetch/checkout の後、source repo から `git config --get user.name` / `user.email` を読む。
+- 値があれば temp clone に `git config user.name` / `git config user.email` を設定する。
+- `user.name` または `user.email` が取れなければ verification/prompt 作成前に hard stop し、identity missing を result notes に明記する。

--- a/scripts/run-local-release-automation.sh
+++ b/scripts/run-local-release-automation.sh
@@ -39,6 +39,10 @@ read_json_field() {
   node -e 'const fs=require("fs"); const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const v=j[process.argv[2]]; process.stdout.write(v === undefined ? "" : String(v));' "$1" "$2"
 }
 
+read_git_config() {
+  git -C "${REPO_ROOT}" config --get "$1" 2>/dev/null || true
+}
+
 candidate_version=$(read_json_field "${status_json}" latest_candidate_version)
 audited_version=$(read_json_field "${status_json}" latest_audited_version)
 published_version=$(read_json_field "${status_json}" published_version)
@@ -102,6 +106,20 @@ EOF
   cat "${result_json}"
   exit 0
 fi
+
+git_user_name=$(read_git_config user.name)
+git_user_email=$(read_git_config user.email)
+
+if [ -z "${git_user_name}" ] || [ -z "${git_user_email}" ]; then
+  cat > "${result_json}" <<EOF
+{"mode":"no_action","candidate_version":"${candidate_version}","audited_version":"${audited_version}","published_version":"${published_version}","verification_passed":false,"promotion_dispatched":false,"publish_dispatched":false,"notes":["identity missing; stopped before verification","user_name_present=$([ -n "${git_user_name}" ] && printf true || printf false)","user_email_present=$([ -n "${git_user_email}" ] && printf true || printf false)","state_file=${local_state_file}"]} 
+EOF
+  cat "${result_json}"
+  exit 0
+fi
+
+git -C "${run_dir}/repo" config user.name "${git_user_name}"
+git -C "${run_dir}/repo" config user.email "${git_user_email}"
 
 if ! git -C "${run_dir}/repo" show-ref --verify --quiet "refs/remotes/${candidate_remote_ref}"; then
   cat > "${result_json}" <<EOF


### PR DESCRIPTION
## Summary
- copy source repo git identity into the temp automation clone
- hard-stop when identity is missing instead of failing later at git commit
- document the runbook and test points

## Verification
- sh -n scripts/run-local-release-automation.sh
- candidate verification success previously reproduced through local automation path
- failure root cause captured as Author identity unknown
