### PR TITLE
Promote native Claude 2.1.136

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ npm install -g @bash0816/claude-code@2.1.122
 npm install -g @bash0816/claude-code@2.1.123
 npm install -g @bash0816/claude-code@2.1.126
 npm install -g @bash0816/claude-code@2.1.128
+npm install -g @bash0816/claude-code@2.1.136
 ```
 
 ## Update / 更新
@@ -69,6 +70,7 @@ Only versions registered in the audited metadata can run.
 - `2.1.123`
 - `2.1.126`
 - `2.1.128`
+- `2.1.136`
 
 The source of truth is the metadata files below.
 

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -48,6 +48,13 @@
       "entry_js_offset": 233148036,
       "entry_end_offset": 247200101,
       "status": "termux_verified"
+    },
+    "2.1.136": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.136",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.136",
+      "entry_js_offset": 214359796,
+      "entry_end_offset": 228641008,
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -54,7 +54,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.136",
       "entry_js_offset": 214359796,
       "entry_end_offset": 228641008,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.128",
-  "latest_candidate_version": "2.1.128",
+  "latest_candidate_version": "2.1.136",
   "previous_stable_version": "2.1.126",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.128",
+  "latest_audited_version": "2.1.136",
   "latest_candidate_version": "2.1.136",
-  "previous_stable_version": "2.1.126",
+  "previous_stable_version": "2.1.128",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -50,6 +50,7 @@ npm install -g @bash0816/claude-code@2.1.122
 npm install -g @bash0816/claude-code@2.1.123
 npm install -g @bash0816/claude-code@2.1.126
 npm install -g @bash0816/claude-code@2.1.128
+npm install -g @bash0816/claude-code@2.1.136
 ```
 
 ## Update / 更新
@@ -74,8 +75,8 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 
 - Only audited versions in `config/claude-native-audited-versions.json` can run.
 - `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。
-- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128` are included in the package metadata.
-- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128` を package metadata に含めています。
+- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136` are included in the package metadata.
+- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。
 - Native artifacts are cached under `${HOME}/.claude-termux-native-package`.

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -48,6 +48,13 @@
       "entry_js_offset": 233148036,
       "entry_end_offset": 247200101,
       "status": "termux_verified"
+    },
+    "2.1.136": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.136",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.136",
+      "entry_js_offset": 214359796,
+      "entry_end_offset": 228641008,
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -54,7 +54,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.136",
       "entry_js_offset": 214359796,
       "entry_end_offset": 228641008,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.128",
-  "latest_candidate_version": "2.1.128",
+  "latest_candidate_version": "2.1.136",
   "previous_stable_version": "2.1.126",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.128",
+  "latest_audited_version": "2.1.136",
   "latest_candidate_version": "2.1.136",
-  "previous_stable_version": "2.1.126",
+  "previous_stable_version": "2.1.128",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.128",
+  "version": "2.1.136",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## Summary
- Promote native Claude 2.1.136 from candidate to termux_verified
- Update release manifest latest_audited_version to 2.1.136
- Update README version guidance for audited install examples

## Verification
- env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 node packages/claude-code/lib/prepare-native.js 2.1.136
- env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.136 sh packages/claude-code/bin/claude --version
- env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.136 sh packages/claude-code/bin/claude auth status
- env CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.136 sh packages/claude-code/bin/claude update --dry-run
- npm install -g --prefix /data/data/com.termux/files/usr/tmp/claude-termux-2.1.136-prefix ./packages/claude-code
- npm pack --dry-run ./packages/claude-code

## Notes
- This PR prepares local branch/PR handoff only. npm publish is not included.
