### PR TITLE
Promote native Claude 2.1.137

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ npm install -g @bash0816/claude-code@2.1.123
 npm install -g @bash0816/claude-code@2.1.126
 npm install -g @bash0816/claude-code@2.1.128
 npm install -g @bash0816/claude-code@2.1.136
+npm install -g @bash0816/claude-code@2.1.137
 ```
 
 ## Update / 更新
@@ -71,6 +72,7 @@ Only versions registered in the audited metadata can run.
 - `2.1.126`
 - `2.1.128`
 - `2.1.136`
+- `2.1.137`
 
 The source of truth is the metadata files below.
 
@@ -108,7 +110,7 @@ Example:
 例:
 
 ```text
-2.1.136 (Claude Code)
+2.1.137 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -55,6 +55,13 @@
       "entry_js_offset": 214359796,
       "entry_end_offset": 228641008,
       "status": "termux_verified"
+    },
+    "2.1.137": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.137",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.137",
+      "entry_js_offset": 214359796,
+      "entry_end_offset": 228641008,
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.136",
-  "latest_candidate_version": "2.1.136",
-  "previous_stable_version": "2.1.128",
+  "latest_audited_version": "2.1.137",
+  "latest_candidate_version": "2.1.137",
+  "previous_stable_version": "2.1.136",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -51,6 +51,7 @@ npm install -g @bash0816/claude-code@2.1.123
 npm install -g @bash0816/claude-code@2.1.126
 npm install -g @bash0816/claude-code@2.1.128
 npm install -g @bash0816/claude-code@2.1.136
+npm install -g @bash0816/claude-code@2.1.137
 ```
 
 ## Update / 更新
@@ -75,8 +76,8 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 
 - Only audited versions in `config/claude-native-audited-versions.json` can run.
 - `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。
-- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136` are included in the package metadata.
-- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136` を package metadata に含めています。
+- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137` are included in the package metadata.
+- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。
 - Native artifacts are cached under `${HOME}/.claude-termux-native-package`.

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -55,6 +55,13 @@
       "entry_js_offset": 214359796,
       "entry_end_offset": 228641008,
       "status": "termux_verified"
+    },
+    "2.1.137": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.137",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.137",
+      "entry_js_offset": 214359796,
+      "entry_end_offset": 228641008,
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.136",
-  "latest_candidate_version": "2.1.136",
-  "previous_stable_version": "2.1.128",
+  "latest_audited_version": "2.1.137",
+  "latest_candidate_version": "2.1.137",
+  "previous_stable_version": "2.1.136",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.136",
+  "version": "2.1.137",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## Summary
- promote native Claude 2.1.137 from candidate to termux_verified
- update release manifest latest_audited_version to 2.1.137
- refresh README version guidance for the newly audited version

## Verification
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 node packages/claude-code/lib/prepare-native.js 2.1.137
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.137 sh packages/claude-code/bin/claude --version
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.137 sh packages/claude-code/bin/claude auth status
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.137 sh packages/claude-code/bin/claude update --dry-run
- npm install -g --prefix /data/data/com.termux/files/usr/tmp/claude-termux-install-check-2.1.137-<pid> ./packages/claude-code

## Notes
- no publish or legacy sync path was used
- handoff is prepared locally on the promotion branch and PR only