### PR TITLE
Serialize pending native candidate queue

### DIFF
--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -121,15 +121,23 @@ jobs:
           candidate_branch="automation/native-claude-${version}"
           branch_exists="$(git ls-remote --heads origin "${candidate_branch}" | wc -l | tr -d " ")"
           open_pr_count="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --head "${candidate_branch}" --json number --jq 'length')"
+          competing_open_count="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --json headRefName --jq '[.[] | select(.headRefName | startswith("automation/native-claude-")) | select(.headRefName != "'"${candidate_branch}"'")] | length')"
           if [ "${branch_exists}" -gt 0 ] || [ "${open_pr_count}" -gt 0 ]; then
-            echo "should_publish_branch=false" >> "${GITHUB_OUTPUT}"
+            echo "should_commit_branch=false" >> "${GITHUB_OUTPUT}"
+            echo "should_open_pr=false" >> "${GITHUB_OUTPUT}"
             echo "Existing candidate branch or PR already exists for ${candidate_branch}"
           else
-            echo "should_publish_branch=true" >> "${GITHUB_OUTPUT}"
+            echo "should_commit_branch=true" >> "${GITHUB_OUTPUT}"
+            if [ "${competing_open_count}" -gt 0 ]; then
+              echo "should_open_pr=false" >> "${GITHUB_OUTPUT}"
+              echo "Another candidate PR is still open; queue ${candidate_branch} as branch-only"
+            else
+              echo "should_open_pr=true" >> "${GITHUB_OUTPUT}"
+            fi
           fi
 
       - name: Commit candidate intake changes
-        if: steps.skip_existing.outputs.should_intake == 'true' && steps.duplicate_guard.outputs.should_publish_branch == 'true'
+        if: steps.skip_existing.outputs.should_intake == 'true' && steps.duplicate_guard.outputs.should_commit_branch == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -149,7 +157,7 @@ jobs:
           git commit -m "Intake native Claude ${version}"
 
       - name: Push candidate branch
-        if: steps.skip_existing.outputs.should_intake == 'true' && steps.duplicate_guard.outputs.should_publish_branch == 'true'
+        if: steps.skip_existing.outputs.should_intake == 'true' && steps.duplicate_guard.outputs.should_commit_branch == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -158,7 +166,7 @@ jobs:
           git push -u origin "${candidate_branch}"
 
       - name: Create candidate PR best-effort
-        if: steps.skip_existing.outputs.should_intake == 'true' && steps.duplicate_guard.outputs.should_publish_branch == 'true'
+        if: steps.skip_existing.outputs.should_intake == 'true' && steps.duplicate_guard.outputs.should_commit_branch == 'true' && steps.duplicate_guard.outputs.should_open_pr == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/release-automation-status.js
+++ b/scripts/release-automation-status.js
@@ -60,7 +60,11 @@ function loadManifestFromGit(cwd, ref) {
   }
 }
 
-function listRemoteBranches(prefix) {
+function refreshOriginRefs(cwd) {
+  run('git', ['fetch', '--prune', 'origin'], cwd, true);
+}
+
+function listRemoteBranches() {
   const result = run('git', ['for-each-ref', '--format=%(refname:short)', 'refs/remotes/origin']);
   return result.stdout ? result.stdout.split('\n').map(line => line.trim()).filter(Boolean) : [];
 }
@@ -77,6 +81,17 @@ function maxVersion(versions) {
   return versions.slice().sort(compareVersions).pop() || '';
 }
 
+function minVersion(versions) {
+  return versions.slice().sort(compareVersions)[0] || '';
+}
+
+function selectCandidateVersion(branches, mainAuditedVersion) {
+  const versions = branches
+    .map(branch => extractVersionFromBranch(branch, 'automation/native-claude-'))
+    .filter(version => compareVersions(version, mainAuditedVersion) > 0);
+  return minVersion(Array.from(new Set(versions)));
+}
+
 function loadPublishedVersion() {
   const result = run('npm', ['view', packageName, 'version'], repoRoot, true);
   return result.status === 0 ? result.stdout : '';
@@ -91,11 +106,8 @@ function loadLegacyMainManifest() {
 }
 
 function loadCandidateVersion(mainAuditedVersion) {
-  const branches = listRemoteBranches('automation/native-claude-');
-  const versions = branches
-    .map(branch => extractVersionFromBranch(branch, 'automation/native-claude-'))
-    .filter(version => compareVersions(version, mainAuditedVersion) > 0);
-  return maxVersion(versions);
+  const branches = listRemoteBranches();
+  return selectCandidateVersion(branches, mainAuditedVersion);
 }
 
 function isLocalVerificationLocked(state, version) {
@@ -106,6 +118,7 @@ function isLocalVerificationLocked(state, version) {
 }
 
 function main() {
+  refreshOriginRefs(repoRoot);
   const localManifest = loadJsonFile(manifestPath);
   const mainManifest = loadManifestFromGit(repoRoot, 'origin/main') || localManifest;
   const devManifest = loadManifestFromGit(repoRoot, 'origin/dev') || mainManifest;
@@ -141,9 +154,17 @@ function main() {
   }
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(error && error.stack ? error.stack : String(error));
-  process.exit(1);
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error && error.stack ? error.stack : String(error));
+    process.exit(1);
+  }
+} else {
+  module.exports = {
+    compareVersions,
+    extractVersionFromBranch,
+    selectCandidateVersion,
+  };
 }

--- a/scripts/release-automation-status.test.js
+++ b/scripts/release-automation-status.test.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  compareVersions,
+  extractVersionFromBranch,
+  selectCandidateVersion,
+} = require('./release-automation-status.js');
+
+test('compareVersions orders numeric patch versions', () => {
+  assert.equal(compareVersions('2.1.136', '2.1.137') < 0, true);
+  assert.equal(compareVersions('2.1.137', '2.1.136') > 0, true);
+  assert.equal(compareVersions('2.1.137', '2.1.137'), 0);
+});
+
+test('extractVersionFromBranch reads automation candidate refs only', () => {
+  assert.equal(
+    extractVersionFromBranch('origin/automation/native-claude-2.1.136', 'automation/native-claude-'),
+    '2.1.136',
+  );
+  assert.equal(
+    extractVersionFromBranch('origin/main', 'automation/native-claude-'),
+    '',
+  );
+});
+
+test('selectCandidateVersion chooses the oldest pending candidate above audited version', () => {
+  const branches = [
+    'origin/main',
+    'origin/automation/native-claude-2.1.128',
+    'origin/automation/native-claude-2.1.136',
+    'origin/automation/native-claude-2.1.137',
+    'origin/automation/native-claude-2.1.137',
+  ];
+  assert.equal(selectCandidateVersion(branches, '2.1.128'), '2.1.136');
+});


### PR DESCRIPTION
## Summary
- fetch origin refs before candidate selection
- select the oldest pending native candidate branch above the audited version
- queue newer candidates as branch-only while another candidate PR is open
- add a fixed 2.1.136/2.1.137 selection test

## Verification
- node --test scripts/release-automation-status.test.js
- node scripts/release-automation-status.js --json
- git diff --check
