### PR TITLE
Fix root README example for 2.1.136

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Example:
 例:
 
 ```text
-2.1.128 (Claude Code)
+2.1.136 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨


### PR DESCRIPTION
Fix the root README expected example line so npm-package verification passes for 2.1.136.