### PR TITLE
Handle shell-indirected native updates

### DIFF
--- a/docs/20260509_native-update-guard-phase3-design-review.md
+++ b/docs/20260509_native-update-guard-phase3-design-review.md
@@ -1,0 +1,44 @@
+# STEP 2: Native Update Guard Phase 3 Design Review
+
+## Proposed Design
+
+Phase 3 では shell command を完全解析しない。代わりに、`sh -c` / `bash -c` / `bash -lc` の 1 段だけ unwrap して、その inner string に既存の `shouldBlockExecString()` を再適用する。
+
+## Rules
+
+### Spawn/ExecFile
+
+- 次の形だけ shallow unwrap する
+  - `sh -c "<command>"`
+  - `bash -c "<command>"`
+  - `bash -lc "<command>"`
+- 上記以外は既存判定のまま
+
+### Exec/ExecSync
+
+- 既存の string tokenization を維持
+- ただし token 先頭が
+  - `sh -c`
+  - `bash -c`
+  - `bash -lc`
+  の場合だけ inner string を再帰 1 回で判定する
+- 実装は `inner string` に既存 guard を再適用するため、単純な入れ子 shell を副次的に拾うことがある
+- ただし parser 自体は shallow tokenizer のままで、完全 shell parser にはしない
+
+### Chaining
+
+- `&&` / `||` / `;` / `|` を完全解釈しない
+- ただし shallow unwrap 後の inner string 全体に既存 `shouldBlockExecString()` を再適用することで、
+  - `sh -c "npm install ... && echo ok"`
+  のような単純例だけ副次的に拾う
+
+## Safety
+
+- unwrap は 1 段のみ
+- shell family は `sh`, `bash` のみ
+- `zsh`, `fish`, `busybox sh` などは scope 外
+
+## Go / No-Go Gate
+
+- 1 段 unwrap で direct official update だけを狙えるなら Go
+- parser 拡張が広すぎて誤爆リスクが上がるなら No-Go

--- a/docs/20260509_native-update-guard-phase3-implementation-plan.md
+++ b/docs/20260509_native-update-guard-phase3-implementation-plan.md
@@ -1,0 +1,26 @@
+# STEP 3: Native Update Guard Phase 3 Implementation Plan
+
+## Implementation Steps
+
+1. `native-update-guard.js`
+   - shell launcher 判定 helper 追加
+   - `sh -c`, `bash -c`, `bash -lc` の shallow unwrap helper 追加
+   - `shouldBlockCommand()` / `shouldBlockExecString()` に 1 段 unwrap を統合
+2. `native-update-guard.test.js`
+   - blocked
+     - `sh -c "npm install -g @anthropic-ai/claude-code"`
+     - `bash -lc "pnpm add -g @anthropic-ai/claude-code"`
+     - `sh -c "corepack yarn global add @anthropic-ai/claude-code"`
+   - non-block
+     - `sh -c "npm install -g @bash0816/claude-code@2.1.137"`
+3. verify
+   - `sh -n packages/claude-code/bin/claude`
+   - `sh -n packages/claude-code/lib/termux-run-claude-native.sh`
+   - `node --check packages/claude-code/lib/native-update-guard.js`
+   - `node --test packages/claude-code/lib/native-update-guard.test.js`
+   - `git diff --check`
+
+## Review Gate
+
+- `GPT-5.5` review で `Go`
+- local verification 全通過

--- a/docs/20260509_native-update-guard-phase3-plan.md
+++ b/docs/20260509_native-update-guard-phase3-plan.md
@@ -1,0 +1,43 @@
+# STEP 1: Native Update Guard Phase 3 Plan
+
+## Goal
+
+Phase 1/2 で未対応の shell indirection 系に対して、誤爆を増やしすぎない shallow guard を追加する。
+
+## Facts
+
+- `2.1.136` と `2.1.137` は完了済み。
+- release automation は
+  - upstream 検出
+  - candidate queue
+  - local cron verification
+  - canonical publish
+  - legacy sync
+  まで通っている。
+- native update guard は Phase 2 まで `main` 反映済み。
+- まだ残る主要経路は
+  - `sh -c "..."`
+  - `bash -lc "..."`
+  - 単純な command chaining を含む shell string
+  である。
+
+## Scope
+
+- `exec` / `execSync` 文字列の shallow unwrap
+- `spawn` / `execFile` の `sh -c`, `bash -lc` 形式の shallow unwrap
+- direct official update だけ block
+
+## Out of Scope
+
+- shell parser の完全実装
+- 入れ子 shell の無制限展開
+- 複雑な pipeline / subshell / heredoc 解釈
+
+## Success Criteria
+
+- 次の direct pattern を block できる
+  - `sh -c "npm install -g @anthropic-ai/claude-code"`
+  - `bash -lc "pnpm add -g @anthropic-ai/claude-code"`
+  - `sh -c "corepack yarn global add @anthropic-ai/claude-code"`
+- canonical package への同型 command は block しない
+- 既存 Phase 1/2 test を壊さない

--- a/packages/claude-code/lib/native-update-guard.js
+++ b/packages/claude-code/lib/native-update-guard.js
@@ -41,6 +41,11 @@ function isCorepackCommand(command) {
   return lastPathSegment(command) === 'corepack';
 }
 
+function isShellCommand(command) {
+  const leaf = lastPathSegment(command);
+  return leaf === 'sh' || leaf === 'bash';
+}
+
 function isSupportedOperation(value) {
   return ['install', 'i', 'add', 'update', 'up', 'upgrade'].includes(String(value || ''));
 }
@@ -120,6 +125,15 @@ function normalizeTokensForExec(tokens) {
   return [normalized.command, ...normalized.args].filter(value => value !== undefined);
 }
 
+function unwrapShellCommand(command, args) {
+  if (!isShellCommand(command) || !Array.isArray(args) || args.length < 2) return null;
+  const first = String(args[0] || '');
+  const second = String(args[1] || '');
+  if ((first === '-c' || first === '-lc') && second) return second;
+  if (first === '-l' && String(args[1] || '') === '-c' && String(args[2] || '')) return String(args[2]);
+  return null;
+}
+
 function tokenizeShellString(command) {
   const text = String(command || '').trim();
   if (!text) return [];
@@ -139,6 +153,8 @@ function unquote(token) {
 function shouldBlockExecString(command) {
   const tokens = normalizeTokensForExec(tokenizeShellString(command).map(unquote));
   if (tokens.length === 0) return false;
+  const shellInner = unwrapShellCommand(tokens[0], tokens.slice(1));
+  if (shellInner) return shouldBlockExecString(shellInner);
   return shouldBlockCommand(tokens[0], tokens.slice(1));
 }
 
@@ -197,6 +213,8 @@ function shouldBlockSpawnArgs(args) {
   if (!Array.isArray(args) || args.length === 0) return false;
   const command = args[0];
   const commandArgs = Array.isArray(args[1]) ? args[1] : [];
+  const shellInner = unwrapShellCommand(command, commandArgs);
+  if (shellInner) return shouldBlockExecString(shellInner);
   return shouldBlockCommand(command, commandArgs);
 }
 

--- a/packages/claude-code/lib/native-update-guard.test.js
+++ b/packages/claude-code/lib/native-update-guard.test.js
@@ -112,6 +112,31 @@ test('blocks exec string through corepack yarn', () => {
   );
 });
 
+test('blocks exec string through sh -c npm install', () => {
+  assert.equal(
+    shouldBlockExecString('sh -c "npm install -g @anthropic-ai/claude-code"'),
+    true,
+  );
+});
+
+test('blocks exec string through bash -lc pnpm add', () => {
+  assert.equal(
+    shouldBlockExecString('bash -lc "pnpm add -g @anthropic-ai/claude-code"'),
+    true,
+  );
+});
+
+test('does not block canonical exec string through bash -lc', () => {
+  assert.equal(
+    shouldBlockExecString('bash -lc "npm install -g @bash0816/claude-code@2.1.137"'),
+    false,
+  );
+});
+
+test('does not block unrelated shell exec string', () => {
+  assert.equal(shouldBlockExecString('sh -c "echo ok"'), false);
+});
+
 function createRealChildStub() {
   const calls = [];
   return {
@@ -240,4 +265,46 @@ test('guarded execSync throws on official npm update shell string', () => {
     error => error && error.code === 'CLAUDE_TERMUX_OFFICIAL_UPDATE_BLOCKED',
   );
   assert.deepEqual(realChild.calls, []);
+});
+
+test('guarded spawn blocks official npm update through sh -c', async () => {
+  const writes = [];
+  const realChild = createRealChildStub();
+  const guarded = createGuardedChildProcess(realChild, value => writes.push(value));
+
+  const child = guarded.spawn('/bin/sh', ['-c', 'npm install -g @anthropic-ai/claude-code']);
+  const result = await new Promise(resolve => {
+    child.once('close', (code, signal) => resolve({ code, signal }));
+  });
+
+  assert.deepEqual(result, { code: 1, signal: null });
+  assert.deepEqual(realChild.calls, []);
+  assert.equal(writes[0], `${BLOCK_MESSAGE}\n`);
+});
+
+test('guarded execFile blocks official update through bash -lc', async () => {
+  const realChild = createRealChildStub();
+  const guarded = createGuardedChildProcess(realChild, () => {});
+
+  const callbackResult = await new Promise(resolve => {
+    guarded.execFile(
+      '/usr/bin/bash',
+      ['-lc', 'pnpm add -g @anthropic-ai/claude-code'],
+      (error, stdout, stderr) => resolve({ error, stdout, stderr }),
+    );
+  });
+
+  assert.equal(callbackResult.error.code, 'CLAUDE_TERMUX_OFFICIAL_UPDATE_BLOCKED');
+  assert.equal(callbackResult.stdout, '');
+  assert.equal(callbackResult.stderr, `${BLOCK_MESSAGE}\n`);
+  assert.deepEqual(realChild.calls, []);
+});
+
+test('guarded spawn delegates canonical shell install', () => {
+  const realChild = createRealChildStub();
+  const guarded = createGuardedChildProcess(realChild, () => {});
+  const result = guarded.spawn('/bin/sh', ['-c', 'npm install -g @bash0816/claude-code@2.1.137']);
+
+  assert.equal(result.kind, 'spawn');
+  assert.equal(realChild.calls.length, 1);
 });


### PR DESCRIPTION
## Summary
- add shallow shell unwrap handling for sh -c / bash -c / bash -lc
- extend native update guard docs and tests
- keep existing canonical update path unchanged

## Verification
- sh -n packages/claude-code/bin/claude
- sh -n packages/claude-code/lib/termux-run-claude-native.sh
- node --check packages/claude-code/lib/native-update-guard.js
- node --test packages/claude-code/lib/native-update-guard.test.js
- git diff --check