### PR TITLE
Promote staging to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm install -g @bash0816/claude-code@2.1.126
 npm install -g @bash0816/claude-code@2.1.128
 npm install -g @bash0816/claude-code@2.1.136
 npm install -g @bash0816/claude-code@2.1.137
+npm install -g @bash0816/claude-code@2.1.138
 ```
 
 ## Update / 更新
@@ -73,6 +74,7 @@ Only versions registered in the audited metadata can run.
 - `2.1.128`
 - `2.1.136`
 - `2.1.137`
+- `2.1.138`
 
 The source of truth is the metadata files below.
 
@@ -110,7 +112,7 @@ Example:
 例:
 
 ```text
-2.1.137 (Claude Code)
+2.1.138 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -62,6 +62,13 @@
       "entry_js_offset": 214359796,
       "entry_end_offset": 228641008,
       "status": "termux_verified"
+    },
+    "2.1.138": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.138",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.138",
+      "entry_js_offset": 214359828,
+      "entry_end_offset": 228641090,
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -68,7 +68,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.138",
       "entry_js_offset": 214359828,
       "entry_end_offset": 228641090,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.137",
-  "latest_candidate_version": "2.1.137",
+  "latest_candidate_version": "2.1.138",
   "previous_stable_version": "2.1.136",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.137",
+  "latest_audited_version": "2.1.138",
   "latest_candidate_version": "2.1.138",
-  "previous_stable_version": "2.1.136",
+  "previous_stable_version": "2.1.137",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -52,6 +52,7 @@ npm install -g @bash0816/claude-code@2.1.126
 npm install -g @bash0816/claude-code@2.1.128
 npm install -g @bash0816/claude-code@2.1.136
 npm install -g @bash0816/claude-code@2.1.137
+npm install -g @bash0816/claude-code@2.1.138
 ```
 
 ## Update / 更新
@@ -76,8 +77,8 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 
 - Only audited versions in `config/claude-native-audited-versions.json` can run.
 - `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。
-- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137` are included in the package metadata.
-- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137` を package metadata に含めています。
+- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137`, `2.1.138` are included in the package metadata.
+- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137`、`2.1.138` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。
 - Native artifacts are cached under `${HOME}/.claude-termux-native-package`.

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -62,6 +62,13 @@
       "entry_js_offset": 214359796,
       "entry_end_offset": 228641008,
       "status": "termux_verified"
+    },
+    "2.1.138": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.138",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.138",
+      "entry_js_offset": 214359828,
+      "entry_end_offset": 228641090,
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -68,7 +68,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.138",
       "entry_js_offset": 214359828,
       "entry_end_offset": 228641090,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.137",
-  "latest_candidate_version": "2.1.137",
+  "latest_candidate_version": "2.1.138",
   "previous_stable_version": "2.1.136",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.137",
+  "latest_audited_version": "2.1.138",
   "latest_candidate_version": "2.1.138",
-  "previous_stable_version": "2.1.136",
+  "previous_stable_version": "2.1.137",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.137",
+  "version": "2.1.138",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## Summary
- promote native Claude 2.1.138 to main

## Verification
- local candidate verification completed for 2.1.138
- prepare-native / version / auth status / update --dry-run / temp-prefix install passed
- local branch/PR handoff completed