### PR TITLE
Fix legacy sync source and promotion flow

### DIFF
--- a/docs/20260510_legacy-sync-origin-main-design-review.md
+++ b/docs/20260510_legacy-sync-origin-main-design-review.md
@@ -1,0 +1,22 @@
+# STEP 2: Legacy Sync Origin Main Design Review
+
+## Proposed Design
+
+`sync-legacy-metadata.js` は canonical worktree の JSON file を直接読む代わりに、既定で `origin/main` の `config/claude-native-audited-versions.json` を `git show` で読む。
+
+必要に応じて source ref は env で override できるが、既定値は `origin/main` に固定する。
+
+## Why
+
+- local feature branch を source にすると、publish 後でも stale data を old repo へ流し得る
+- legacy sync の source of truth は stable branch であるべき
+
+## Safety
+
+- `origin/main` が取得できない時だけ fallback を考える
+- ただし silent fallback は避け、最低でも failure を明示する
+
+## Go / No-Go
+
+- `origin/main` 読み取りに寄せられるなら Go
+- local worktree fallback を常用する設計なら No-Go

--- a/docs/20260510_legacy-sync-origin-main-implementation-plan.md
+++ b/docs/20260510_legacy-sync-origin-main-implementation-plan.md
@@ -1,0 +1,12 @@
+# STEP 3: Legacy Sync Origin Main Implementation Plan
+
+1. `sync-legacy-metadata.js`
+   - canonical source ref を `origin/main` 既定で追加
+   - `git show <ref>:config/claude-native-audited-versions.json` を読む
+2. `sync-legacy-metadata.sh`
+   - 必要なら source ref env を明示
+3. verify
+   - `node --check scripts/sync-legacy-metadata.js`
+   - `sh -n scripts/sync-legacy-metadata.sh`
+   - temp canonical source なしでも local feature branch 上から old repo sync が成立すること
+4. `2.1.138` sync 完了後に status 再確認

--- a/docs/20260510_legacy-sync-origin-main-plan.md
+++ b/docs/20260510_legacy-sync-origin-main-plan.md
@@ -1,0 +1,22 @@
+# STEP 1: Legacy Sync Origin Main Plan
+
+## Goal
+
+legacy sync が local canonical worktree の branch 状態に引きずられず、常に canonical `origin/main` を source of truth にする。
+
+## Facts
+
+- `needs_legacy_sync=true` のときでも、local canonical worktree が feature branch だと `sync-legacy-metadata.js` は古い metadata を読む。
+- 今回 `2.1.138` で old repo sync が止まった直接原因はこれ。
+- 完全自動化では、legacy sync source は release 済み canonical `origin/main` でなければならない。
+
+## Scope
+
+- `scripts/sync-legacy-metadata.js`
+- 必要なら `scripts/sync-legacy-metadata.sh`
+- local verification
+
+## Success Criteria
+
+- local canonical branch に依存せず、`origin/main` の verified versions を old repo へ反映できる
+- `2.1.138` の old repo sync を完了できる

--- a/scripts/sync-legacy-metadata.js
+++ b/scripts/sync-legacy-metadata.js
@@ -4,11 +4,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const cp = require('child_process');
 
 const canonicalRepoRoot = path.resolve(__dirname, '..');
 const legacyRepoRoot = process.env.CLAUDE_TERMUX_LEGACY_REPO_ROOT || path.join(os.homedir(), 'CluadeCode-Termux-public');
-
-const canonicalConfigFile = path.join(canonicalRepoRoot, 'config', 'claude-native-audited-versions.json');
+const canonicalSourceRef = process.env.CLAUDE_TERMUX_CANONICAL_SOURCE_REF || 'origin/main';
 const legacyRootConfigFile = path.join(legacyRepoRoot, 'config', 'claude-native-audited-versions.json');
 const legacyPackageConfigFile = path.join(legacyRepoRoot, 'packages', 'cluade-code', 'config', 'claude-native-audited-versions.json');
 
@@ -25,6 +25,22 @@ function compareVersions(a, b) {
 
 function loadJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function run(command, args, cwd) {
+  const result = cp.spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+  }
+  return result.stdout;
+}
+
+function loadCanonicalConfigFromRef(ref) {
+  const raw = run('git', ['show', `${ref}:config/claude-native-audited-versions.json`], canonicalRepoRoot);
+  return JSON.parse(raw);
 }
 
 function saveJson(file, data) {
@@ -48,7 +64,7 @@ function main() {
     throw new Error(`legacy repo root not found: ${legacyRepoRoot}`);
   }
 
-  const canonicalConfig = loadJson(canonicalConfigFile);
+  const canonicalConfig = loadCanonicalConfigFromRef(canonicalSourceRef);
   const legacyRootConfig = loadJson(legacyRootConfigFile);
   const legacyPackageConfig = loadJson(legacyPackageConfigFile);
   const verifiedVersions = pickVerifiedVersions(canonicalConfig);

--- a/scripts/sync-legacy-metadata.sh
+++ b/scripts/sync-legacy-metadata.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 CANONICAL_REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
 LEGACY_REPO_ROOT="${CLAUDE_TERMUX_LEGACY_REPO_ROOT:-${HOME}/CluadeCode-Termux-public}"
 LEGACY_REPO_SLUG="${CLAUDE_TERMUX_LEGACY_REPO_SLUG:-bash0816/CluadeCode-Termux}"
+CANONICAL_SOURCE_REF="${CLAUDE_TERMUX_CANONICAL_SOURCE_REF:-origin/main}"
 DRY_RUN=0
 ACTIVE_LEGACY_REPO_ROOT="${LEGACY_REPO_ROOT}"
 TMP_REPO_ROOT=""
@@ -218,7 +219,14 @@ ensure_pr_merged() {
   body="$4"
   temp_branch="$5"
 
-  record=$(read_pr_record "${base}" "${head}" || true)
+  effective_head="${head}"
+
+  if [ -n "${temp_branch}" ] && [ "${DRY_RUN}" -ne 1 ]; then
+    prepare_temp_promotion_branch "${temp_branch}" "${base}" "${head}"
+    effective_head="${temp_branch}"
+  fi
+
+  record=$(read_pr_record "${base}" "${effective_head}" || true)
   state=$(pr_state "${record}")
   number=$(pr_number "${record}")
   url=$(pr_url "${record}")
@@ -231,28 +239,17 @@ ensure_pr_merged() {
 
   if [ "${state}" = "MERGED" ]; then
     [ -n "${url}" ] && add_pr "${url}"
-    add_note "already merged ${head} -> ${base}"
+    add_note "already merged ${effective_head} -> ${base}"
     return
   fi
 
   if [ -z "${number}" ]; then
-    create_output=$(create_pr "${base}" "${head}" "${title}" "${body}" || true)
-    if printf '%s' "${create_output}" | grep -q "No commits between"; then
-      [ -n "${temp_branch}" ] || fail "pr create no-commits without fallback branch: ${head} -> ${base}"
-      add_note "using fallback branch ${temp_branch} for ${head} -> ${base}"
-      prepare_temp_promotion_branch "${temp_branch}" "${base}" "${head}"
-      head="${temp_branch}"
-      record=$(read_pr_record "${base}" "${head}" || true)
-      number=$(pr_number "${record}")
-      if [ -z "${number}" ]; then
-        create_output=$(create_pr "${base}" "${head}" "${title}" "${body}" || true)
-      fi
-    fi
-    record=$(read_pr_record "${base}" "${head}" || true)
+    create_output=$(create_pr "${base}" "${effective_head}" "${title}" "${body}" || true)
+    record=$(read_pr_record "${base}" "${effective_head}" || true)
     number=$(pr_number "${record}")
     state=$(pr_state "${record}")
     url=$(pr_url "${record}")
-    [ -n "${number}" ] || fail "pr create failed: ${head} -> ${base}"
+    [ -n "${number}" ] || fail "pr create failed: ${effective_head} -> ${base}"
   fi
 
   [ -n "${url}" ] && add_pr "${url}"
@@ -288,6 +285,7 @@ if [ "${DRY_RUN}" -eq 1 ]; then
 fi
 
 git -C "${ACTIVE_LEGACY_REPO_ROOT}" fetch --prune origin >/dev/null 2>&1 || fail "legacy fetch failed"
+git -C "${CANONICAL_REPO_ROOT}" fetch --prune origin >/dev/null 2>&1 || fail "canonical fetch failed"
 ensure_clean_worktree
 git -C "${ACTIVE_LEGACY_REPO_ROOT}" config user.name "${git_user_name}"
 git -C "${ACTIVE_LEGACY_REPO_ROOT}" config user.email "${git_user_email}"
@@ -305,7 +303,7 @@ SYNC_BRANCH="${feature_branch}"
 
 git -C "${ACTIVE_LEGACY_REPO_ROOT}" checkout -B "${feature_branch}" "origin/main" >/dev/null 2>&1
 
-CLAUDE_TERMUX_LEGACY_REPO_ROOT="${ACTIVE_LEGACY_REPO_ROOT}" node "${CANONICAL_REPO_ROOT}/scripts/sync-legacy-metadata.js" || fail "legacy metadata sync failed"
+CLAUDE_TERMUX_LEGACY_REPO_ROOT="${ACTIVE_LEGACY_REPO_ROOT}" CLAUDE_TERMUX_CANONICAL_SOURCE_REF="${CANONICAL_SOURCE_REF}" node "${CANONICAL_REPO_ROOT}/scripts/sync-legacy-metadata.js" || fail "legacy metadata sync failed"
 node "${ACTIVE_LEGACY_REPO_ROOT}/scripts/update-release-manifest.js" || fail "legacy manifest update failed"
 node "${ACTIVE_LEGACY_REPO_ROOT}/scripts/update-readme-version-guidance.js" || fail "legacy readme update failed"
 


### PR DESCRIPTION
## Summary
- make legacy sync read canonical metadata from origin/main instead of the local worktree
- add canonical fetch gating to legacy sync
- use version-specific temp promotion branches for legacy staging/main handoff

## Verification
- node --check scripts/sync-legacy-metadata.js
- sh -n scripts/sync-legacy-metadata.sh
- git diff --check
- verified 2.1.138 legacy sync completion to latest_legacy_synced_version=2.1.138