### PR TITLE
Promote native Claude 2.1.139

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npm install -g @bash0816/claude-code@2.1.128
 npm install -g @bash0816/claude-code@2.1.136
 npm install -g @bash0816/claude-code@2.1.137
 npm install -g @bash0816/claude-code@2.1.138
+npm install -g @bash0816/claude-code@2.1.139
 ```
 
 ## Update / 更新
@@ -75,6 +76,7 @@ Only versions registered in the audited metadata can run.
 - `2.1.136`
 - `2.1.137`
 - `2.1.138`
+- `2.1.139`
 
 The source of truth is the metadata files below.
 
@@ -112,7 +114,7 @@ Example:
 例:
 
 ```text
-2.1.138 (Claude Code)
+2.1.139 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -69,6 +69,13 @@
       "entry_js_offset": 214359828,
       "entry_end_offset": 228641090,
       "status": "termux_verified"
+    },
+    "2.1.139": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.139",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.139",
+      "entry_js_offset": 214907060,
+      "entry_end_offset": 229261135,
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -75,7 +75,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.139",
       "entry_js_offset": 214907060,
       "entry_end_offset": 229261135,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.138",
+  "latest_audited_version": "2.1.139",
   "latest_candidate_version": "2.1.139",
-  "previous_stable_version": "2.1.137",
+  "previous_stable_version": "2.1.138",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.138",
-  "latest_candidate_version": "2.1.138",
+  "latest_candidate_version": "2.1.139",
   "previous_stable_version": "2.1.137",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -53,6 +53,7 @@ npm install -g @bash0816/claude-code@2.1.128
 npm install -g @bash0816/claude-code@2.1.136
 npm install -g @bash0816/claude-code@2.1.137
 npm install -g @bash0816/claude-code@2.1.138
+npm install -g @bash0816/claude-code@2.1.139
 ```
 
 ## Update / 更新
@@ -77,8 +78,8 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 
 - Only audited versions in `config/claude-native-audited-versions.json` can run.
 - `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。
-- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137`, `2.1.138` are included in the package metadata.
-- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137`、`2.1.138` を package metadata に含めています。
+- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137`, `2.1.138`, `2.1.139` are included in the package metadata.
+- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137`、`2.1.138`、`2.1.139` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。
 - Native artifacts are cached under `${HOME}/.claude-termux-native-package`.

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -69,6 +69,13 @@
       "entry_js_offset": 214359828,
       "entry_end_offset": 228641090,
       "status": "termux_verified"
+    },
+    "2.1.139": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.139",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.139",
+      "entry_js_offset": 214907060,
+      "entry_end_offset": 229261135,
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -75,7 +75,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.139",
       "entry_js_offset": 214907060,
       "entry_end_offset": 229261135,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.138",
+  "latest_audited_version": "2.1.139",
   "latest_candidate_version": "2.1.139",
-  "previous_stable_version": "2.1.137",
+  "previous_stable_version": "2.1.138",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.138",
-  "latest_candidate_version": "2.1.138",
+  "latest_candidate_version": "2.1.139",
   "previous_stable_version": "2.1.137",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.138",
+  "version": "2.1.139",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## Summary\n- promote Claude Code 2.1.139 from candidate to termux_verified\n- update release manifests for latest_audited_version=2.1.139\n\n## Verification\n- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 node packages/claude-code/lib/prepare-native.js 2.1.139\n- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.139 sh packages/claude-code/bin/claude --version\n- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.139 sh packages/claude-code/bin/claude auth status\n- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.139 sh packages/claude-code/bin/claude update --dry-run\n- npm install -g --prefix <temp-prefix> ./packages/claude-code\n\n## Notes\n- no publish or legacy sync path was used\n