### PR TITLE
Add release self-heal reconciliation

### DIFF
--- a/docs/20260513_release-self-heal-design-review.md
+++ b/docs/20260513_release-self-heal-design-review.md
@@ -1,0 +1,129 @@
+# 2026-05-13 Release Self-Heal Design Review
+
+## Proposed Design
+
+release automation に 2 つの self-heal line を追加する。
+
+### 1. State Reconciliation
+
+`release-automation-status.js` に candidate reconcile を追加する。
+
+対象:
+
+- state file
+- remote candidate branch
+- open candidate PR
+- `origin/main` / `origin/dev` / `origin/staging`
+
+方針:
+
+1. `promotion_dispatched` でも固定 lock にしない
+2. 次を毎回再評価する
+   - candidate branch exists
+   - candidate PR open / merged / absent
+   - `origin/main` audited version
+3. `promotion_dispatched` は
+   - branch / PR / branch promotion が未完なら `pending_promotion`
+   - `main` がその version 以上なら complete
+   と扱う
+4. hard-stop 条件
+   - merge conflict
+   - PR unmergeable
+   - required checks failure
+   - workflow dispatch failure
+   を state/result に残す
+
+### 2. Auto Promotion Line
+
+`run-local-release-automation.sh` が起動する local `codex exec --full-auto` の prompt を拡張し、
+canonical promotion reconcile を同じ run の中で続行できるようにする。
+
+順序:
+
+1. candidate branch verification を再実行できるよう stale lock を外す
+2. candidate PR `automation/native-claude-<version> -> dev` を確認
+3. README drift など sync-only drift があれば candidate branch 上で self-heal して push
+4. open candidate PR が mergeable かつ visible checks success なら merge
+5. `dev -> staging` PR を create / merge
+6. `staging -> main` PR を create / merge
+7. `main` が target version に達したら `npm-package.yml` を dispatch
+8. publish 完了後に legacy sync を続行
+
+merge 条件:
+
+1. PR state is `OPEN`
+2. `mergeStateStatus` is mergeable family
+3. visible checks are completed and have no failure
+4. conflict / draft / unknown なら hard-stop
+5. head SHA は fetch 後の current remote head と一致していること
+
+### Branch Promotion Rule
+
+canonical 側でも legacy sync と同じく、
+promotion branch を version 固有 temp branch で切る。
+
+例:
+
+- `automation/promote-dev-to-staging-2.1.139`
+- `automation/promote-staging-to-main-2.1.139`
+
+理由:
+
+- 過去 PR の再利用誤判定を避ける
+- 各 version の promotion を識別可能にする
+
+具体手順:
+
+1. `dev -> staging`
+   - temp branch は `origin/staging` から切る
+   - `origin/dev` を merge
+   - PR head=temp branch, base=`staging`
+2. `staging -> main`
+   - temp branch は `origin/main` から切る
+   - `origin/staging` を merge
+   - PR head=temp branch, base=`main`
+
+### Publish Dispatch Rule
+
+publish は local で `gh workflow run npm-package.yml` を使って dispatch する。
+
+条件:
+
+1. `origin/main` audited version == target version
+2. npm published version < target version
+3. workflow input
+   - `publish=true`
+   - `npm_tag=latest`
+4. dispatch 後は run success まで追う
+5. npm published version >= target version を確認してから legacy sync に進む
+
+### State Update Rule
+
+state file / result JSON は次で更新する。
+
+- verification 開始時
+  - `verification_in_progress`
+- verification 成功後、candidate PR / branch promotion / publish が残る
+  - `pending_promotion`
+- publish dispatch 中
+  - `publish_dispatched`
+- `main` 反映 + npm published + legacy sync 未完
+  - canonical は complete 扱い、legacy は別 result で続行
+- hard-stop
+  - `promotion_failed`
+  - notes に stage と reason を残す
+
+### No-Go Conditions
+
+- `gh` auth が使えない
+- merge conflict
+- candidate PR merge failure
+- publish workflow dispatch failure
+
+この場合は hard-stop して state と result JSON に残す。
+
+## Go / No-Go
+
+- self-heal が state reconcile と auto-promotion に分離されていれば Go
+- stale lock を state file 書き換えだけで隠すなら No-Go
+- `main` 反映前に publish dispatch するなら No-Go

--- a/docs/20260513_release-self-heal-implementation-plan.md
+++ b/docs/20260513_release-self-heal-implementation-plan.md
@@ -1,0 +1,51 @@
+# 2026-05-13 Release Self-Heal Implementation Plan
+
+1. `release-automation-status.js` に candidate reconcile を追加する
+2. stale `promotion_dispatched` を fixed lock にせず、branch/PR/main 状態から再評価する
+3. `run-local-release-automation.sh` の local `codex exec --full-auto` prompt を拡張する
+   - candidate drift self-heal
+   - candidate PR merge
+   - `dev -> staging`
+   - `staging -> main`
+   - publish dispatch
+   - legacy sync
+   を同じ flow で扱えるようにする
+4. candidate PR merge 前に
+   - mergeable state
+   - draft ではない
+   - head SHA 一致
+   - visible checks success
+   を確認する
+5. `dev -> staging` / `staging -> main` の version 固有 temp PR promotion を追加する
+   - `origin/staging` / `origin/main` 起点 merge を固定
+6. `main` 到達後の npm publish workflow dispatch を追加する
+   - dispatch 後の run は
+     - workflow name
+     - event=`workflow_dispatch`
+     - head branch=`main`
+     - dispatch 後 createdAt
+     で特定する
+   - run success と npm published version を確認する
+7. result JSON に
+   - promotion stage
+   - merged PR URLs
+   - publish dispatch result
+   を残す
+8. state file に
+   - `pending_promotion`
+   - `publish_dispatched`
+   - `promotion_failed`
+   の更新条件を明記どおり反映する
+
+## Verification
+
+- `node --check scripts/release-automation-status.js`
+- `sh -n scripts/run-local-release-automation.sh`
+- local status JSON diff
+- current stuck case `2.1.139` で reconcile が前へ進むこと
+
+## Deliverable
+
+- self-heal / auto-promotion diff
+- docs
+- reviewer gate

--- a/docs/20260513_release-self-heal-plan.md
+++ b/docs/20260513_release-self-heal-plan.md
@@ -1,0 +1,28 @@
+# 2026-05-13 Release Self-Heal Plan
+
+## Goal
+
+`ClaudeCode-Termux` の release automation が、candidate verification 後に
+人手確認待ちで止まらないようにする。
+
+## Facts
+
+- current local status は `latest_audited_version=2.1.138`
+- current candidate は `2.1.139`
+- state file では `2.1.139: promotion_dispatched`
+- open candidate PR は `automation/native-claude-2.1.139 -> dev`
+- public workflows は `claude-native-version-watch.yml` と `npm-package.yml` のみ
+- current local automation は verification と candidate PR handoff で止まる
+
+## Problem
+
+- `promotion_dispatched` が stale でも self-heal しない
+- candidate PR が open のままでも local automation が次段 promotion を実行しない
+- `dev -> staging -> main -> npm publish` が自動連結されていない
+
+## Success
+
+- stale state を local reconcile で再評価できる
+- open candidate PR があれば local automation が merge まで進める
+- `dev -> staging -> main` も local automation が自動 promotion する
+- `main` 更新後は npm publish workflow を local automation が dispatch する

--- a/scripts/release-automation-status.js
+++ b/scripts/release-automation-status.js
@@ -110,11 +110,15 @@ function loadCandidateVersion(mainAuditedVersion) {
   return selectCandidateVersion(branches, mainAuditedVersion);
 }
 
-function isLocalVerificationLocked(state, version) {
+function candidateStateStatus(state, version) {
   if (!version) return false;
   const item = state.candidates && state.candidates[version];
-  if (!item) return false;
-  return item.status === 'verification_in_progress' || item.status === 'promotion_dispatched';
+  return item && item.status ? String(item.status) : '';
+}
+
+function isLocalVerificationLocked(state, version) {
+  const status = candidateStateStatus(state, version);
+  return status === 'verification_in_progress';
 }
 
 function main() {
@@ -129,6 +133,7 @@ function main() {
   const latestAudited = mainManifest.latest_audited_version || '';
   const latestCandidate = loadCandidateVersion(latestAudited) || devManifest.latest_candidate_version || latestAudited;
   const latestLegacySyncedVersion = legacyManifest ? (legacyManifest.latest_audited_version || '') : '';
+  const candidateState = candidateStateStatus(state, latestCandidate);
   const localVerificationLocked = isLocalVerificationLocked(state, latestCandidate);
 
   const result = {
@@ -137,6 +142,7 @@ function main() {
     latest_candidate_version: latestCandidate,
     published_version: publishedVersion,
     latest_legacy_synced_version: latestLegacySyncedVersion,
+    candidate_state_status: candidateState,
     local_verification_locked: localVerificationLocked,
     local_state_file: stateFile,
     needs_verification: Boolean(latestCandidate) && compareVersions(latestCandidate, latestAudited) > 0 && !localVerificationLocked,

--- a/scripts/run-local-release-automation.sh
+++ b/scripts/run-local-release-automation.sh
@@ -56,6 +56,7 @@ needs_verification=$(read_json_field "${status_json}" needs_verification)
 needs_publish=$(read_json_field "${status_json}" needs_publish)
 needs_legacy_sync=$(read_json_field "${status_json}" needs_legacy_sync)
 local_verification_locked=$(read_json_field "${status_json}" local_verification_locked)
+candidate_state_status=$(read_json_field "${status_json}" candidate_state_status)
 local_state_file=$(read_json_field "${status_json}" local_state_file)
 candidate_branch="automation/native-claude-${candidate_version}"
 candidate_remote_ref="origin/${candidate_branch}"
@@ -90,6 +91,11 @@ apply_result_state() {
   result_candidate=$(read_json_field "${result_json}" candidate_version)
   result_passed=$(read_json_field "${result_json}" verification_passed)
   result_dispatched=$(read_json_field "${result_json}" promotion_dispatched)
+  result_publish=$(read_json_field "${result_json}" publish_dispatched)
+  if [ "${result_candidate}" = "${candidate_version}" ] && [ "${result_passed}" = "true" ] && [ "${result_publish}" = "true" ]; then
+    write_state "${candidate_version}" "publish_dispatched"
+    return
+  fi
   if [ "${result_candidate}" = "${candidate_version}" ] && [ "${result_passed}" = "true" ] && [ "${result_dispatched}" = "true" ]; then
     write_state "${candidate_version}" "promotion_dispatched"
     return
@@ -119,6 +125,8 @@ EOF
   note="no candidate verification required"
   if [ "${local_verification_locked}" = "true" ]; then
     note="candidate verification locked by local state"
+  elif [ "${candidate_state_status}" = "promotion_dispatched" ] || [ "${candidate_state_status}" = "pending_promotion" ] || [ "${candidate_state_status}" = "publish_dispatched" ]; then
+    note="candidate promotion follow-up is pending a fresh reconcile run"
   elif [ "${needs_publish}" = "true" ]; then
     note="canonical publish pending in GitHub Actions follow-up"
   elif [ "${needs_legacy_sync}" = "true" ]; then
@@ -178,10 +186,25 @@ Task:
    git commit -m "Promote native Claude ${candidate_version}"
    git push --force-with-lease origin ${candidate_branch}
    if no open PR exists, gh pr create --repo bash0816/ClaudeCode-Termux --base ${BASE_BRANCH} --head ${candidate_branch}
-4. Do not use the removed workflow or any publish/legacy sync path.
-5. Final answer must be JSON matching the provided schema.
-6. Set promotion_dispatched=true only when the local branch / PR handoff is prepared.
-7. If promotion_dispatched=true, notes must explicitly say it means local branch/PR handoff prepared and not GitHub workflow dispatch.
+4. Then continue the canonical release flow automatically.
+   - check candidate PR ${candidate_branch} -> ${BASE_BRANCH}
+   - if README drift or similar sync-only drift is the reason checks failed, repair it on ${candidate_branch}, push it, and wait for the PR check to rerun
+   - merge candidate PR when state is OPEN, not draft, merge state is acceptable, and all visible checks are completed without failure
+   - promote ${BASE_BRANCH} -> staging by using a versioned temp branch named automation/promote-dev-to-staging-${candidate_version}
+   - promote staging -> main by using a versioned temp branch named automation/promote-staging-to-main-${candidate_version}
+   - after origin/main reaches ${candidate_version}, dispatch npm-package.yml with publish=true and npm_tag=latest
+   - wait for the workflow_dispatch run of Npm Package on main to succeed
+   - verify npm view @bash0816/claude-code version reaches ${candidate_version}
+   - if legacy sync is still needed, run sh scripts/sync-legacy-metadata.sh ${candidate_version}
+5. Hard-stop instead of guessing when:
+   - merge conflict
+   - draft PR
+   - failed checks that are not simple sync drift
+   - publish workflow failure
+   - npm published version does not advance
+6. Final answer must be JSON matching the provided schema.
+7. Set promotion_dispatched=true only when promotion moved beyond candidate verification into PR merge / branch promotion / publish follow-up.
+8. Set publish_dispatched=true only when the publish workflow was dispatched and confirmed successful.
 EOF
 
 if [ "${DRY_RUN}" -eq 1 ]; then


### PR DESCRIPTION
## Summary
- stop treating promotion_dispatched as a fixed local verification lock
- expose candidate state in release-automation-status.js
- extend local codex follow-up prompt so it can repair candidate drift and continue promotion/publish flow
- add self-heal plan, design review, and implementation plan docs

## Verification
- node --check scripts/release-automation-status.js
- sh -n scripts/run-local-release-automation.sh
- release-automation-status.js now reports 2.1.139 as candidate_state_status=promotion_dispatched with local_verification_locked=false and needs_verification=true

## Notes
- this is intended to unblock the current 2.1.139 stuck case and reduce manual intervention for future candidates
