### PR TITLE
Add candidate rebuild self-heal

### DIFF
--- a/docs/20260513_release-self-heal-design-review.md
+++ b/docs/20260513_release-self-heal-design-review.md
@@ -2,128 +2,41 @@
 
 ## Proposed Design
 
-release automation に 2 つの self-heal line を追加する。
+release automation の self-heal を 2 層で維持する。
 
 ### 1. State Reconciliation
 
-`release-automation-status.js` に candidate reconcile を追加する。
+`promotion_dispatched` は fixed lock にしない。
 
-対象:
+扱い:
 
-- state file
-- remote candidate branch
-- open candidate PR
-- `origin/main` / `origin/dev` / `origin/staging`
+- `verification_in_progress`
+  - verification lock
+- `promotion_dispatched`
+  - follow-up state
+- `publish_dispatched`
+  - publish 完了済み follow-up state
+
+### 2. Candidate Rebuild On DIRTY
+
+`run-local-release-automation.sh` が生成する local Codex prompt に、
+candidate PR が `DIRTY` のときの rebuild 手順を含める。
 
 方針:
 
-1. `promotion_dispatched` でも固定 lock にしない
-2. 次を毎回再評価する
-   - candidate branch exists
-   - candidate PR open / merged / absent
-   - `origin/main` audited version
-3. `promotion_dispatched` は
-   - branch / PR / branch promotion が未完なら `pending_promotion`
-   - `main` がその version 以上なら complete
-   と扱う
-4. hard-stop 条件
-   - merge conflict
-   - PR unmergeable
-   - required checks failure
-   - workflow dispatch failure
-   を state/result に残す
-
-### 2. Auto Promotion Line
-
-`run-local-release-automation.sh` が起動する local `codex exec --full-auto` の prompt を拡張し、
-canonical promotion reconcile を同じ run の中で続行できるようにする。
-
-順序:
-
-1. candidate branch verification を再実行できるよう stale lock を外す
-2. candidate PR `automation/native-claude-<version> -> dev` を確認
-3. README drift など sync-only drift があれば candidate branch 上で self-heal して push
-4. open candidate PR が mergeable かつ visible checks success なら merge
-5. `dev -> staging` PR を create / merge
-6. `staging -> main` PR を create / merge
-7. `main` が target version に達したら `npm-package.yml` を dispatch
-8. publish 完了後に legacy sync を続行
-
-merge 条件:
-
-1. PR state is `OPEN`
-2. `mergeStateStatus` is mergeable family
-3. visible checks are completed and have no failure
-4. conflict / draft / unknown なら hard-stop
-5. head SHA は fetch 後の current remote head と一致していること
-
-### Branch Promotion Rule
-
-canonical 側でも legacy sync と同じく、
-promotion branch を version 固有 temp branch で切る。
-
-例:
-
-- `automation/promote-dev-to-staging-2.1.139`
-- `automation/promote-staging-to-main-2.1.139`
+1. candidate branch を `origin/dev` へ reset
+2. `termux-prepare-claude-native-version.js` で offset を再取得
+3. `add-candidate-metadata.js` で `offset_discovered` を再生成
+4. `promote-verified-version.js` と manifest / README update を再実行
+5. candidate branch を force-push
+6. PR check rerun 後に merge 判定へ戻る
 
 理由:
 
-- 過去 PR の再利用誤判定を避ける
-- 各 version の promotion を識別可能にする
-
-具体手順:
-
-1. `dev -> staging`
-   - temp branch は `origin/staging` から切る
-   - `origin/dev` を merge
-   - PR head=temp branch, base=`staging`
-2. `staging -> main`
-   - temp branch は `origin/main` から切る
-   - `origin/staging` を merge
-   - PR head=temp branch, base=`main`
-
-### Publish Dispatch Rule
-
-publish は local で `gh workflow run npm-package.yml` を使って dispatch する。
-
-条件:
-
-1. `origin/main` audited version == target version
-2. npm published version < target version
-3. workflow input
-   - `publish=true`
-   - `npm_tag=latest`
-4. dispatch 後は run success まで追う
-5. npm published version >= target version を確認してから legacy sync に進む
-
-### State Update Rule
-
-state file / result JSON は次で更新する。
-
-- verification 開始時
-  - `verification_in_progress`
-- verification 成功後、candidate PR / branch promotion / publish が残る
-  - `pending_promotion`
-- publish dispatch 中
-  - `publish_dispatched`
-- `main` 反映 + npm published + legacy sync 未完
-  - canonical は complete 扱い、legacy は別 result で続行
-- hard-stop
-  - `promotion_failed`
-  - notes に stage と reason を残す
-
-### No-Go Conditions
-
-- `gh` auth が使えない
-- merge conflict
-- candidate PR merge failure
-- publish workflow dispatch failure
-
-この場合は hard-stop して state と result JSON に残す。
+- stale candidate branch の `DIRTY` は metadata drift ではなく base branch drift だから
+- repo 本体に新しい helper script を増やさず、既存 intake toolchain を再利用できるから
 
 ## Go / No-Go
 
-- self-heal が state reconcile と auto-promotion に分離されていれば Go
-- stale lock を state file 書き換えだけで隠すなら No-Go
-- `main` 反映前に publish dispatch するなら No-Go
+- 既存 intake toolchain を再利用して `DIRTY` candidate を再構成できるなら Go
+- `DIRTY` を user 手作業前提のまま残すなら No-Go

--- a/docs/20260513_release-self-heal-implementation-plan.md
+++ b/docs/20260513_release-self-heal-implementation-plan.md
@@ -1,51 +1,18 @@
 # 2026-05-13 Release Self-Heal Implementation Plan
 
-1. `release-automation-status.js` に candidate reconcile を追加する
-2. stale `promotion_dispatched` を fixed lock にせず、branch/PR/main 状態から再評価する
-3. `run-local-release-automation.sh` の local `codex exec --full-auto` prompt を拡張する
-   - candidate drift self-heal
-   - candidate PR merge
-   - `dev -> staging`
-   - `staging -> main`
-   - publish dispatch
-   - legacy sync
-   を同じ flow で扱えるようにする
-4. candidate PR merge 前に
-   - mergeable state
-   - draft ではない
-   - head SHA 一致
-   - visible checks success
-   を確認する
-5. `dev -> staging` / `staging -> main` の version 固有 temp PR promotion を追加する
-   - `origin/staging` / `origin/main` 起点 merge を固定
-6. `main` 到達後の npm publish workflow dispatch を追加する
-   - dispatch 後の run は
-     - workflow name
-     - event=`workflow_dispatch`
-     - head branch=`main`
-     - dispatch 後 createdAt
-     で特定する
-   - run success と npm published version を確認する
-7. result JSON に
-   - promotion stage
-   - merged PR URLs
-   - publish dispatch result
-   を残す
-8. state file に
-   - `pending_promotion`
-   - `publish_dispatched`
-   - `promotion_failed`
-   の更新条件を明記どおり反映する
+1. `run-local-release-automation.sh` の canonical flow prompt に `DIRTY` candidate rebuild 手順を追加する
+2. rebuild 手順は
+   - `origin/dev` reset
+   - `termux-prepare-claude-native-version.js`
+   - `add-candidate-metadata.js`
+   - `promote-verified-version.js`
+   - manifest / README update
+   - force-push
+   を使う
+3. docs を `docs/` に追加する
 
 ## Verification
 
-- `node --check scripts/release-automation-status.js`
 - `sh -n scripts/run-local-release-automation.sh`
-- local status JSON diff
-- current stuck case `2.1.139` で reconcile が前へ進むこと
-
-## Deliverable
-
-- self-heal / auto-promotion diff
-- docs
-- reviewer gate
+- `git diff --check`
+- 修正反映後に `2.1.141` intake から publish まで通す

--- a/docs/20260513_release-self-heal-plan.md
+++ b/docs/20260513_release-self-heal-plan.md
@@ -7,22 +7,19 @@
 
 ## Facts
 
-- current local status は `latest_audited_version=2.1.138`
-- current candidate は `2.1.139`
-- state file では `2.1.139: promotion_dispatched`
-- open candidate PR は `automation/native-claude-2.1.139 -> dev`
-- public workflows は `claude-native-version-watch.yml` と `npm-package.yml` のみ
-- current local automation は verification と candidate PR handoff で止まる
+- `2.1.140` 完了後も local state file には `promotion_dispatched` が残った
+- stale `promotion_dispatched` は次 candidate の固定 lock にはしない方針が既に必要だった
+- `2.1.140` candidate PR は `dev` が先に `2.1.139` を取り込んだため `DIRTY` になった
+- candidate branch を `origin/dev` ベースで再構成すると `PR #90` は解消できた
+- `2.1.141` はまだ candidate intake されていない
 
 ## Problem
 
-- `promotion_dispatched` が stale でも self-heal しない
-- candidate PR が open のままでも local automation が次段 promotion を実行しない
-- `dev -> staging -> main -> npm publish` が自動連結されていない
+- stale state を見て user が確認しないと release 状態を誤読する
+- stale candidate branch が `dev` に追従できず、`DIRTY` を local automation が自己修復できない
 
 ## Success
 
-- stale state を local reconcile で再評価できる
-- open candidate PR があれば local automation が merge まで進める
-- `dev -> staging -> main` も local automation が自動 promotion する
-- `main` 更新後は npm publish workflow を local automation が dispatch する
+- stale `promotion_dispatched` が verification lock にならない
+- local automation prompt が `DIRTY` candidate branch の rebuild 手順を持つ
+- 修正を `feature/* -> dev -> staging -> main` で反映した後、`2.1.141` の intake から publish まで通せる

--- a/scripts/run-local-release-automation.sh
+++ b/scripts/run-local-release-automation.sh
@@ -188,6 +188,15 @@ Task:
    if no open PR exists, gh pr create --repo bash0816/ClaudeCode-Termux --base ${BASE_BRANCH} --head ${candidate_branch}
 4. Then continue the canonical release flow automatically.
    - check candidate PR ${candidate_branch} -> ${BASE_BRANCH}
+   - if the candidate PR is DIRTY because ${BASE_BRANCH} advanced after intake, rebuild ${candidate_branch} from origin/${BASE_BRANCH} before retrying:
+     1. reset local ${candidate_branch} to origin/${BASE_BRANCH}
+     2. run WORKDIR=<temp-dir> node scripts/termux-prepare-claude-native-version.js @${candidate_version} --json > <prepare-json>
+     3. run node scripts/add-candidate-metadata.js ${candidate_version} <prepare-json>
+     4. rerun node scripts/update-release-manifest.js
+     5. rerun node scripts/promote-verified-version.js ${candidate_version}
+     6. rerun node scripts/update-release-manifest.js
+     7. rerun node scripts/update-readme-version-guidance.js
+     8. commit and force-push ${candidate_branch} again
    - if README drift or similar sync-only drift is the reason checks failed, repair it on ${candidate_branch}, push it, and wait for the PR check to rerun
    - merge candidate PR when state is OPEN, not draft, merge state is acceptable, and all visible checks are completed without failure
    - promote ${BASE_BRANCH} -> staging by using a versioned temp branch named automation/promote-dev-to-staging-${candidate_version}


### PR DESCRIPTION
## Summary
- add DIRTY candidate rebuild guidance to local release automation
- document stale promotion state and candidate rebuild flow

## Verification
- sh -n scripts/run-local-release-automation.sh
- git diff --check