### PR TITLE
Promote staging to main for 2.1.141

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ npm install -g @bash0816/claude-code@2.1.137
 npm install -g @bash0816/claude-code@2.1.138
 npm install -g @bash0816/claude-code@2.1.139
 npm install -g @bash0816/claude-code@2.1.140
+npm install -g @bash0816/claude-code@2.1.141
 ```
 
 ## Update / 更新
@@ -79,6 +80,7 @@ Only versions registered in the audited metadata can run.
 - `2.1.138`
 - `2.1.139`
 - `2.1.140`
+- `2.1.141`
 
 The source of truth is the metadata files below.
 
@@ -116,7 +118,7 @@ Example:
 例:
 
 ```text
-2.1.140 (Claude Code)
+2.1.141 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -83,6 +83,13 @@
       "entry_js_offset": 215244548,
       "entry_end_offset": 229639310,
       "status": "termux_verified"
+    },
+    "2.1.141": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.141",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.141",
+      "entry_js_offset": 216126612,
+      "entry_end_offset": 230636245,
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -89,7 +89,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.141",
       "entry_js_offset": 216126612,
       "entry_end_offset": 230636245,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.140",
-  "latest_candidate_version": "2.1.140",
+  "latest_candidate_version": "2.1.141",
   "previous_stable_version": "2.1.139",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.140",
+  "latest_audited_version": "2.1.141",
   "latest_candidate_version": "2.1.141",
-  "previous_stable_version": "2.1.139",
+  "previous_stable_version": "2.1.140",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -55,6 +55,7 @@ npm install -g @bash0816/claude-code@2.1.137
 npm install -g @bash0816/claude-code@2.1.138
 npm install -g @bash0816/claude-code@2.1.139
 npm install -g @bash0816/claude-code@2.1.140
+npm install -g @bash0816/claude-code@2.1.141
 ```
 
 ## Update / 更新
@@ -79,8 +80,8 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 
 - Only audited versions in `config/claude-native-audited-versions.json` can run.
 - `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。
-- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137`, `2.1.138`, `2.1.139`, `2.1.140` are included in the package metadata.
-- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137`、`2.1.138`、`2.1.139`、`2.1.140` を package metadata に含めています。
+- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137`, `2.1.138`, `2.1.139`, `2.1.140`, `2.1.141` are included in the package metadata.
+- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137`、`2.1.138`、`2.1.139`、`2.1.140`、`2.1.141` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。
 - Native artifacts are cached under `${HOME}/.claude-termux-native-package`.

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -83,6 +83,13 @@
       "entry_js_offset": 215244548,
       "entry_end_offset": 229639310,
       "status": "termux_verified"
+    },
+    "2.1.141": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.141",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.141",
+      "entry_js_offset": 216126612,
+      "entry_end_offset": 230636245,
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -89,7 +89,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.141",
       "entry_js_offset": 216126612,
       "entry_end_offset": 230636245,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.140",
-  "latest_candidate_version": "2.1.140",
+  "latest_candidate_version": "2.1.141",
   "previous_stable_version": "2.1.139",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.140",
+  "latest_audited_version": "2.1.141",
   "latest_candidate_version": "2.1.141",
-  "previous_stable_version": "2.1.139",
+  "previous_stable_version": "2.1.140",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.140",
+  "version": "2.1.141",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Summary:\n- promote staging to main\n- target audited version: 2.1.141\n\nSource:\n- base: main\n- head: automation/promote-staging-to-main-2.1.141 (merged origin/staging)