### PR TITLE
Promote native Claude 2.1.142

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npm install -g @bash0816/claude-code@2.1.138
 npm install -g @bash0816/claude-code@2.1.139
 npm install -g @bash0816/claude-code@2.1.140
 npm install -g @bash0816/claude-code@2.1.141
+npm install -g @bash0816/claude-code@2.1.142
 ```
 
 ## Update / 更新
@@ -81,6 +82,7 @@ Only versions registered in the audited metadata can run.
 - `2.1.139`
 - `2.1.140`
 - `2.1.141`
+- `2.1.142`
 
 The source of truth is the metadata files below.
 
@@ -118,7 +120,7 @@ Example:
 例:
 
 ```text
-2.1.141 (Claude Code)
+2.1.142 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -90,6 +90,13 @@
       "entry_js_offset": 216126612,
       "entry_end_offset": 230636245,
       "status": "termux_verified"
+    },
+    "2.1.142": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.142",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.142",
+      "entry_js_offset": 216179028,
+      "entry_end_offset": 230687382,
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -96,7 +96,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.142",
       "entry_js_offset": 216179028,
       "entry_end_offset": 230687382,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.141",
-  "latest_candidate_version": "2.1.141",
+  "latest_candidate_version": "2.1.142",
   "previous_stable_version": "2.1.140",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.141",
+  "latest_audited_version": "2.1.142",
   "latest_candidate_version": "2.1.142",
-  "previous_stable_version": "2.1.140",
+  "previous_stable_version": "2.1.141",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -56,6 +56,7 @@ npm install -g @bash0816/claude-code@2.1.138
 npm install -g @bash0816/claude-code@2.1.139
 npm install -g @bash0816/claude-code@2.1.140
 npm install -g @bash0816/claude-code@2.1.141
+npm install -g @bash0816/claude-code@2.1.142
 ```
 
 ## Update / 更新
@@ -80,8 +81,8 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 
 - Only audited versions in `config/claude-native-audited-versions.json` can run.
 - `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。
-- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137`, `2.1.138`, `2.1.139`, `2.1.140`, `2.1.141` are included in the package metadata.
-- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137`、`2.1.138`、`2.1.139`、`2.1.140`、`2.1.141` を package metadata に含めています。
+- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137`, `2.1.138`, `2.1.139`, `2.1.140`, `2.1.141`, `2.1.142` are included in the package metadata.
+- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137`、`2.1.138`、`2.1.139`、`2.1.140`、`2.1.141`、`2.1.142` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。
 - Native artifacts are cached under `${HOME}/.claude-termux-native-package`.

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -90,6 +90,13 @@
       "entry_js_offset": 216126612,
       "entry_end_offset": 230636245,
       "status": "termux_verified"
+    },
+    "2.1.142": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.142",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.142",
+      "entry_js_offset": 216179028,
+      "entry_end_offset": 230687382,
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -96,7 +96,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.142",
       "entry_js_offset": 216179028,
       "entry_end_offset": 230687382,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.141",
-  "latest_candidate_version": "2.1.141",
+  "latest_candidate_version": "2.1.142",
   "previous_stable_version": "2.1.140",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.141",
+  "latest_audited_version": "2.1.142",
   "latest_candidate_version": "2.1.142",
-  "previous_stable_version": "2.1.140",
+  "previous_stable_version": "2.1.141",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.141",
+  "version": "2.1.142",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## Summary\n- verify candidate 2.1.142 on Termux wrapper path\n- promote 2.1.142 to termux_verified\n- sync release manifest and README guidance\n\n## Verification\n- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 node packages/claude-code/lib/prepare-native.js 2.1.142\n- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.142 sh packages/claude-code/bin/claude --version\n- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.142 sh packages/claude-code/bin/claude auth status\n- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.142 sh packages/claude-code/bin/claude update --dry-run\n- npm install -g --prefix /data/data/com.termux/files/usr/tmp/claude-verify-2.1.142.UxcY4Q/prefix ./packages/claude-code