### PR TITLE
Harden native fetch and release self-heal

### DIFF
--- a/packages/claude-code/lib/prepare-native.js
+++ b/packages/claude-code/lib/prepare-native.js
@@ -11,6 +11,9 @@ const config = require(path.join(packageDir, 'config', 'claude-native-audited-ve
 const pkg = require(path.join(packageDir, 'package.json'));
 const version = process.argv[2] || pkg.version;
 const item = config.versions[version];
+const curlRetries = process.env.CLAUDE_TERMUX_FETCH_RETRIES || '4';
+const curlConnectTimeout = process.env.CLAUDE_TERMUX_FETCH_CONNECT_TIMEOUT || '20';
+const curlMaxTime = process.env.CLAUDE_TERMUX_FETCH_MAX_TIME || '300';
 
 if (!item) {
   console.error(`Unsupported audited Claude Code version: ${version}`);
@@ -31,15 +34,11 @@ fs.mkdirSync(versionDir, { recursive: true });
 const packDir = fs.mkdtempSync(path.join(os.tmpdir(), `claude-code-${version}-`));
 
 try {
-  run('npm', ['pack', item.native_spec, '--pack-destination', packDir]);
-  const tgz = fs.readdirSync(packDir).find(name => name.endsWith('.tgz'));
-  if (!tgz) {
-    throw new Error('npm pack did not produce a tgz');
-  }
+  const tgzPath = fetchNativeTarball(item.native_spec, packDir);
 
   const extractDir = path.join(packDir, 'native');
   fs.mkdirSync(extractDir, { recursive: true });
-  run('tar', ['-xzf', path.join(packDir, tgz), '-C', extractDir]);
+  run('tar', ['-xzf', tgzPath, '-C', extractDir]);
 
   fs.rmSync(nativeDest, { recursive: true, force: true });
   fs.mkdirSync(path.dirname(nativeDest), { recursive: true });
@@ -54,6 +53,50 @@ function run(command, args) {
   if (result.status !== 0) {
     throw new Error(`${command} ${args.join(' ')} failed`);
   }
+}
+
+function runCapture(command, args) {
+  const result = cp.spawnSync(command, args, {
+    stdio: ['ignore', 'pipe', 'inherit'],
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed`);
+  }
+  return result.stdout.trim();
+}
+
+function fetchNativeTarball(spec, packDir) {
+  const directTarball = path.join(packDir, 'native-package.tgz');
+
+  try {
+    const tarballUrl = runCapture('npm', ['view', spec, 'dist.tarball', '--json']).replace(/^"|"$/g, '');
+    if (!tarballUrl) {
+      throw new Error(`npm view did not return dist.tarball for ${spec}`);
+    }
+    run('curl', [
+      '--fail',
+      '--location',
+      '--retry', String(curlRetries),
+      '--connect-timeout', String(curlConnectTimeout),
+      '--max-time', String(curlMaxTime),
+      '--output', directTarball,
+      tarballUrl,
+    ]);
+    if (fs.existsSync(directTarball)) {
+      return directTarball;
+    }
+  } catch (error) {
+    console.error(`Direct tarball fetch failed for ${spec}; falling back to npm pack.`);
+    console.error(error && error.message ? error.message : String(error));
+  }
+
+  run('npm', ['pack', spec, '--pack-destination', packDir]);
+  const tgz = fs.readdirSync(packDir).find(name => name.endsWith('.tgz'));
+  if (!tgz) {
+    throw new Error('npm pack did not produce a tgz');
+  }
+  return path.join(packDir, tgz);
 }
 
 function validateOffsets(file, audited) {

--- a/scripts/run-local-release-automation.sh
+++ b/scripts/run-local-release-automation.sh
@@ -44,6 +44,25 @@ read_git_config() {
   git -C "${REPO_ROOT}" config --get "$1" 2>/dev/null || true
 }
 
+read_global_git_config() {
+  git config --global --get "$1" 2>/dev/null || true
+}
+
+resolve_identity_fallback() {
+  field="$1"
+  if [ "$field" = "user.name" ]; then
+    gh api user --jq '.login' 2>/dev/null || true
+    return
+  fi
+  if [ "$field" = "user.email" ]; then
+    login="$(gh api user --jq '.login' 2>/dev/null || true)"
+    if [ -n "$login" ]; then
+      printf '%s\n' "${login}@users.noreply.github.com"
+    fi
+    return
+  fi
+}
+
 is_valid_json_file() {
   [ -f "$1" ] || return 1
   node -e 'JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));' "$1" >/dev/null 2>&1
@@ -166,6 +185,19 @@ fi
 git_user_name=$(read_git_config user.name)
 git_user_email=$(read_git_config user.email)
 
+if [ -z "${git_user_name}" ]; then
+  git_user_name=$(read_global_git_config user.name)
+fi
+if [ -z "${git_user_email}" ]; then
+  git_user_email=$(read_global_git_config user.email)
+fi
+if [ -z "${git_user_name}" ]; then
+  git_user_name=$(resolve_identity_fallback user.name)
+fi
+if [ -z "${git_user_email}" ]; then
+  git_user_email=$(resolve_identity_fallback user.email)
+fi
+
 if [ -z "${git_user_name}" ] || [ -z "${git_user_email}" ]; then
   cat > "${result_json}" <<EOF
 {"mode":"no_action","candidate_version":"${candidate_version}","audited_version":"${audited_version}","published_version":"${published_version}","verification_passed":false,"promotion_dispatched":false,"publish_dispatched":false,"notes":["identity missing; stopped before verification","user_name_present=$([ -n "${git_user_name}" ] && printf true || printf false)","user_email_present=$([ -n "${git_user_email}" ] && printf true || printf false)","state_file=${local_state_file}"]} 
@@ -260,3 +292,16 @@ codex exec \
 apply_result_state
 
 cat "${result_json}"
+
+post_status_json="${log_dir}/post-status.json"
+node "${run_dir}/repo/scripts/release-automation-status.js" --json > "${post_status_json}" || true
+post_needs_verification=$(read_json_field "${post_status_json}" needs_verification)
+post_needs_publish=$(read_json_field "${post_status_json}" needs_publish)
+post_needs_legacy_sync=$(read_json_field "${post_status_json}" needs_legacy_sync)
+
+if [ "${post_needs_verification}" != "true" ] && [ "${post_needs_publish}" != "true" ] && [ "${post_needs_legacy_sync}" != "true" ]; then
+  gh workflow run claude-native-version-watch.yml \
+    --repo bash0816/ClaudeCode-Termux \
+    --ref main \
+    -f version=@latest >/dev/null 2>&1 || true
+fi

--- a/scripts/termux-prepare-claude-native-version.js
+++ b/scripts/termux-prepare-claude-native-version.js
@@ -8,6 +8,9 @@ const path = require('path');
 
 const requested = process.argv[2] || '@latest';
 const jsonOnly = process.argv.includes('--json');
+const curlRetries = process.env.CLAUDE_TERMUX_FETCH_RETRIES || '4';
+const curlConnectTimeout = process.env.CLAUDE_TERMUX_FETCH_CONNECT_TIMEOUT || '20';
+const curlMaxTime = process.env.CLAUDE_TERMUX_FETCH_MAX_TIME || '300';
 
 function normalizeVersion(input) {
   if (input === '@latest' || input === 'latest') return 'latest';
@@ -33,6 +36,39 @@ function resolveVersion(input) {
     return run('npm', ['view', '@anthropic-ai/claude-code', 'version'], { capture: true });
   }
   return normalized;
+}
+
+function fetchNativeTarball(spec, packDir) {
+  const directTarball = path.join(packDir, 'native-package.tgz');
+
+  try {
+    const tarballUrl = run('npm', ['view', spec, 'dist.tarball', '--json'], { capture: true }).replace(/^"|"$/g, '');
+    if (!tarballUrl) {
+      throw new Error(`npm view did not return dist.tarball for ${spec}`);
+    }
+    run('curl', [
+      '--fail',
+      '--location',
+      '--retry', String(curlRetries),
+      '--connect-timeout', String(curlConnectTimeout),
+      '--max-time', String(curlMaxTime),
+      '--output', directTarball,
+      tarballUrl,
+    ], { quiet: jsonOnly });
+    if (fs.existsSync(directTarball)) {
+      return directTarball;
+    }
+  } catch (error) {
+    if (!jsonOnly) {
+      console.error(`Direct tarball fetch failed for ${spec}; falling back to npm pack.`);
+      console.error(error && error.message ? error.message : String(error));
+    }
+  }
+
+  run('npm', ['pack', spec, '--pack-destination', packDir], { quiet: jsonOnly });
+  const tgz = fs.readdirSync(packDir).find(name => name.endsWith('.tgz'));
+  if (!tgz) throw new Error('npm pack did not produce a tgz');
+  return path.join(packDir, tgz);
 }
 
 function discoverOffsets(binary) {
@@ -78,13 +114,11 @@ function main() {
   fs.mkdirSync(nativeDest, { recursive: true });
 
   try {
-    run('npm', ['pack', nativeSpec, '--pack-destination', packDir], { quiet: jsonOnly });
-    const tgz = fs.readdirSync(packDir).find(name => name.endsWith('.tgz'));
-    if (!tgz) throw new Error('npm pack did not produce a tgz');
+    const tgzPath = fetchNativeTarball(nativeSpec, packDir);
 
     const extractDir = path.join(packDir, 'native');
     fs.mkdirSync(extractDir, { recursive: true });
-    run('tar', ['-xzf', path.join(packDir, tgz), '-C', extractDir], { quiet: jsonOnly });
+    run('tar', ['-xzf', tgzPath, '-C', extractDir], { quiet: jsonOnly });
     fs.rmSync(nativeDest, { recursive: true, force: true });
     fs.cpSync(path.join(extractDir, 'package'), nativeDest, { recursive: true });
 


### PR DESCRIPTION
## Summary
- switch native candidate fetch from npm pack-only to direct tarball download with fallback
- add local automation identity fallback and post-run intake refresh
- unblock Termux candidate verification when upstream native tarball exists but npm pack stalls

## Validation
- sh -n scripts/run-local-release-automation.sh
- node --check packages/claude-code/lib/prepare-native.js
- node --check scripts/termux-prepare-claude-native-version.js
- timeout 300s env WORKDIR=/data/data/com.termux/files/usr/tmp/claude-2142-candidate node scripts/termux-prepare-claude-native-version.js @2.1.142 --json
- node scripts/release-automation-status.js --json