### PR TITLE
Promote native Claude 2.1.143

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npm install -g @bash0816/claude-code@2.1.139
 npm install -g @bash0816/claude-code@2.1.140
 npm install -g @bash0816/claude-code@2.1.141
 npm install -g @bash0816/claude-code@2.1.142
+npm install -g @bash0816/claude-code@2.1.143
 ```
 
 ## Update / 更新
@@ -83,6 +84,7 @@ Only versions registered in the audited metadata can run.
 - `2.1.140`
 - `2.1.141`
 - `2.1.142`
+- `2.1.143`
 
 The source of truth is the metadata files below.
 
@@ -120,7 +122,7 @@ Example:
 例:
 
 ```text
-2.1.142 (Claude Code)
+2.1.143 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -103,7 +103,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.143",
       "entry_js_offset": 216602500,
       "entry_end_offset": 231151175,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -97,6 +97,13 @@
       "entry_js_offset": 216179028,
       "entry_end_offset": 230687382,
       "status": "termux_verified"
+    },
+    "2.1.143": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.143",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.143",
+      "entry_js_offset": 216602500,
+      "entry_end_offset": 231151175,
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.142",
+  "latest_audited_version": "2.1.143",
   "latest_candidate_version": "2.1.143",
-  "previous_stable_version": "2.1.141",
+  "previous_stable_version": "2.1.142",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.142",
-  "latest_candidate_version": "2.1.142",
+  "latest_candidate_version": "2.1.143",
   "previous_stable_version": "2.1.141",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -57,6 +57,7 @@ npm install -g @bash0816/claude-code@2.1.139
 npm install -g @bash0816/claude-code@2.1.140
 npm install -g @bash0816/claude-code@2.1.141
 npm install -g @bash0816/claude-code@2.1.142
+npm install -g @bash0816/claude-code@2.1.143
 ```
 
 ## Update / 更新
@@ -81,8 +82,8 @@ Normal launch also checks the same manifest with a short timeout and prints a no
 
 - Only audited versions in `config/claude-native-audited-versions.json` can run.
 - `config/claude-native-audited-versions.json` にある監査済み version だけを実行できます。
-- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137`, `2.1.138`, `2.1.139`, `2.1.140`, `2.1.141`, `2.1.142` are included in the package metadata.
-- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137`、`2.1.138`、`2.1.139`、`2.1.140`、`2.1.141`、`2.1.142` を package metadata に含めています。
+- `2.1.118`, `2.1.119`, `2.1.121`, `2.1.122`, `2.1.123`, `2.1.126`, `2.1.128`, `2.1.136`, `2.1.137`, `2.1.138`, `2.1.139`, `2.1.140`, `2.1.141`, `2.1.142`, `2.1.143` are included in the package metadata.
+- `2.1.118`、`2.1.119`、`2.1.121`、`2.1.122`、`2.1.123`、`2.1.126`、`2.1.128`、`2.1.136`、`2.1.137`、`2.1.138`、`2.1.139`、`2.1.140`、`2.1.141`、`2.1.142`、`2.1.143` を package metadata に含めています。
 - The metadata file is the source of truth for the currently audited set.
 - 現在の監査済み version 集合の source of truth は metadata file です。
 - Native artifacts are cached under `${HOME}/.claude-termux-native-package`.

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -103,7 +103,7 @@
       "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.143",
       "entry_js_offset": 216602500,
       "entry_end_offset": 231151175,
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -97,6 +97,13 @@
       "entry_js_offset": 216179028,
       "entry_end_offset": 230687382,
       "status": "termux_verified"
+    },
+    "2.1.143": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.143",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.143",
+      "entry_js_offset": 216602500,
+      "entry_end_offset": 231151175,
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.142",
+  "latest_audited_version": "2.1.143",
   "latest_candidate_version": "2.1.143",
-  "previous_stable_version": "2.1.141",
+  "previous_stable_version": "2.1.142",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.142",
-  "latest_candidate_version": "2.1.142",
+  "latest_candidate_version": "2.1.143",
   "previous_stable_version": "2.1.141",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/lib/prepare-native.js
+++ b/packages/claude-code/lib/prepare-native.js
@@ -11,6 +11,9 @@ const config = require(path.join(packageDir, 'config', 'claude-native-audited-ve
 const pkg = require(path.join(packageDir, 'package.json'));
 const version = process.argv[2] || pkg.version;
 const item = config.versions[version];
+const curlRetries = process.env.CLAUDE_TERMUX_FETCH_RETRIES || '4';
+const curlConnectTimeout = process.env.CLAUDE_TERMUX_FETCH_CONNECT_TIMEOUT || '20';
+const curlMaxTime = process.env.CLAUDE_TERMUX_FETCH_MAX_TIME || '300';
 
 if (!item) {
   console.error(`Unsupported audited Claude Code version: ${version}`);
@@ -31,15 +34,11 @@ fs.mkdirSync(versionDir, { recursive: true });
 const packDir = fs.mkdtempSync(path.join(os.tmpdir(), `claude-code-${version}-`));
 
 try {
-  run('npm', ['pack', item.native_spec, '--pack-destination', packDir]);
-  const tgz = fs.readdirSync(packDir).find(name => name.endsWith('.tgz'));
-  if (!tgz) {
-    throw new Error('npm pack did not produce a tgz');
-  }
+  const tgzPath = fetchNativeTarball(item.native_spec, packDir);
 
   const extractDir = path.join(packDir, 'native');
   fs.mkdirSync(extractDir, { recursive: true });
-  run('tar', ['-xzf', path.join(packDir, tgz), '-C', extractDir]);
+  run('tar', ['-xzf', tgzPath, '-C', extractDir]);
 
   fs.rmSync(nativeDest, { recursive: true, force: true });
   fs.mkdirSync(path.dirname(nativeDest), { recursive: true });
@@ -54,6 +53,50 @@ function run(command, args) {
   if (result.status !== 0) {
     throw new Error(`${command} ${args.join(' ')} failed`);
   }
+}
+
+function runCapture(command, args) {
+  const result = cp.spawnSync(command, args, {
+    stdio: ['ignore', 'pipe', 'inherit'],
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed`);
+  }
+  return result.stdout.trim();
+}
+
+function fetchNativeTarball(spec, packDir) {
+  const directTarball = path.join(packDir, 'native-package.tgz');
+
+  try {
+    const tarballUrl = runCapture('npm', ['view', spec, 'dist.tarball', '--json']).replace(/^"|"$/g, '');
+    if (!tarballUrl) {
+      throw new Error(`npm view did not return dist.tarball for ${spec}`);
+    }
+    run('curl', [
+      '--fail',
+      '--location',
+      '--retry', String(curlRetries),
+      '--connect-timeout', String(curlConnectTimeout),
+      '--max-time', String(curlMaxTime),
+      '--output', directTarball,
+      tarballUrl,
+    ]);
+    if (fs.existsSync(directTarball)) {
+      return directTarball;
+    }
+  } catch (error) {
+    console.error(`Direct tarball fetch failed for ${spec}; falling back to npm pack.`);
+    console.error(error && error.message ? error.message : String(error));
+  }
+
+  run('npm', ['pack', spec, '--pack-destination', packDir]);
+  const tgz = fs.readdirSync(packDir).find(name => name.endsWith('.tgz'));
+  if (!tgz) {
+    throw new Error('npm pack did not produce a tgz');
+  }
+  return path.join(packDir, tgz);
 }
 
 function validateOffsets(file, audited) {

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.142",
+  "version": "2.1.143",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {

--- a/scripts/run-local-release-automation.sh
+++ b/scripts/run-local-release-automation.sh
@@ -44,6 +44,25 @@ read_git_config() {
   git -C "${REPO_ROOT}" config --get "$1" 2>/dev/null || true
 }
 
+read_global_git_config() {
+  git config --global --get "$1" 2>/dev/null || true
+}
+
+resolve_identity_fallback() {
+  field="$1"
+  if [ "$field" = "user.name" ]; then
+    gh api user --jq '.login' 2>/dev/null || true
+    return
+  fi
+  if [ "$field" = "user.email" ]; then
+    login="$(gh api user --jq '.login' 2>/dev/null || true)"
+    if [ -n "$login" ]; then
+      printf '%s\n' "${login}@users.noreply.github.com"
+    fi
+    return
+  fi
+}
+
 is_valid_json_file() {
   [ -f "$1" ] || return 1
   node -e 'JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));' "$1" >/dev/null 2>&1
@@ -166,6 +185,19 @@ fi
 git_user_name=$(read_git_config user.name)
 git_user_email=$(read_git_config user.email)
 
+if [ -z "${git_user_name}" ]; then
+  git_user_name=$(read_global_git_config user.name)
+fi
+if [ -z "${git_user_email}" ]; then
+  git_user_email=$(read_global_git_config user.email)
+fi
+if [ -z "${git_user_name}" ]; then
+  git_user_name=$(resolve_identity_fallback user.name)
+fi
+if [ -z "${git_user_email}" ]; then
+  git_user_email=$(resolve_identity_fallback user.email)
+fi
+
 if [ -z "${git_user_name}" ] || [ -z "${git_user_email}" ]; then
   cat > "${result_json}" <<EOF
 {"mode":"no_action","candidate_version":"${candidate_version}","audited_version":"${audited_version}","published_version":"${published_version}","verification_passed":false,"promotion_dispatched":false,"publish_dispatched":false,"notes":["identity missing; stopped before verification","user_name_present=$([ -n "${git_user_name}" ] && printf true || printf false)","user_email_present=$([ -n "${git_user_email}" ] && printf true || printf false)","state_file=${local_state_file}"]} 
@@ -260,3 +292,16 @@ codex exec \
 apply_result_state
 
 cat "${result_json}"
+
+post_status_json="${log_dir}/post-status.json"
+node "${run_dir}/repo/scripts/release-automation-status.js" --json > "${post_status_json}" || true
+post_needs_verification=$(read_json_field "${post_status_json}" needs_verification)
+post_needs_publish=$(read_json_field "${post_status_json}" needs_publish)
+post_needs_legacy_sync=$(read_json_field "${post_status_json}" needs_legacy_sync)
+
+if [ "${post_needs_verification}" != "true" ] && [ "${post_needs_publish}" != "true" ] && [ "${post_needs_legacy_sync}" != "true" ]; then
+  gh workflow run claude-native-version-watch.yml \
+    --repo bash0816/ClaudeCode-Termux \
+    --ref main \
+    -f version=@latest >/dev/null 2>&1 || true
+fi

--- a/scripts/termux-prepare-claude-native-version.js
+++ b/scripts/termux-prepare-claude-native-version.js
@@ -8,6 +8,9 @@ const path = require('path');
 
 const requested = process.argv[2] || '@latest';
 const jsonOnly = process.argv.includes('--json');
+const curlRetries = process.env.CLAUDE_TERMUX_FETCH_RETRIES || '4';
+const curlConnectTimeout = process.env.CLAUDE_TERMUX_FETCH_CONNECT_TIMEOUT || '20';
+const curlMaxTime = process.env.CLAUDE_TERMUX_FETCH_MAX_TIME || '300';
 
 function normalizeVersion(input) {
   if (input === '@latest' || input === 'latest') return 'latest';
@@ -33,6 +36,39 @@ function resolveVersion(input) {
     return run('npm', ['view', '@anthropic-ai/claude-code', 'version'], { capture: true });
   }
   return normalized;
+}
+
+function fetchNativeTarball(spec, packDir) {
+  const directTarball = path.join(packDir, 'native-package.tgz');
+
+  try {
+    const tarballUrl = run('npm', ['view', spec, 'dist.tarball', '--json'], { capture: true }).replace(/^"|"$/g, '');
+    if (!tarballUrl) {
+      throw new Error(`npm view did not return dist.tarball for ${spec}`);
+    }
+    run('curl', [
+      '--fail',
+      '--location',
+      '--retry', String(curlRetries),
+      '--connect-timeout', String(curlConnectTimeout),
+      '--max-time', String(curlMaxTime),
+      '--output', directTarball,
+      tarballUrl,
+    ], { quiet: jsonOnly });
+    if (fs.existsSync(directTarball)) {
+      return directTarball;
+    }
+  } catch (error) {
+    if (!jsonOnly) {
+      console.error(`Direct tarball fetch failed for ${spec}; falling back to npm pack.`);
+      console.error(error && error.message ? error.message : String(error));
+    }
+  }
+
+  run('npm', ['pack', spec, '--pack-destination', packDir], { quiet: jsonOnly });
+  const tgz = fs.readdirSync(packDir).find(name => name.endsWith('.tgz'));
+  if (!tgz) throw new Error('npm pack did not produce a tgz');
+  return path.join(packDir, tgz);
 }
 
 function discoverOffsets(binary) {
@@ -78,13 +114,11 @@ function main() {
   fs.mkdirSync(nativeDest, { recursive: true });
 
   try {
-    run('npm', ['pack', nativeSpec, '--pack-destination', packDir], { quiet: jsonOnly });
-    const tgz = fs.readdirSync(packDir).find(name => name.endsWith('.tgz'));
-    if (!tgz) throw new Error('npm pack did not produce a tgz');
+    const tgzPath = fetchNativeTarball(nativeSpec, packDir);
 
     const extractDir = path.join(packDir, 'native');
     fs.mkdirSync(extractDir, { recursive: true });
-    run('tar', ['-xzf', path.join(packDir, tgz), '-C', extractDir], { quiet: jsonOnly });
+    run('tar', ['-xzf', tgzPath, '-C', extractDir], { quiet: jsonOnly });
     fs.rmSync(nativeDest, { recursive: true, force: true });
     fs.cpSync(path.join(extractDir, 'package'), nativeDest, { recursive: true });
 


### PR DESCRIPTION
## Summary
- verify native Claude 2.1.143 on Termux wrapper path
- promote 2.1.143 from candidate to termux_verified
- update release manifest and README guidance

## Verification
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 node packages/claude-code/lib/prepare-native.js 2.1.143
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.143 sh packages/claude-code/bin/claude --version
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.143 sh packages/claude-code/bin/claude auth status
- CLAUDE_TERMUX_SKIP_UPDATE_CHECK=1 CLAUDE_TERMUX_CLAUDE_VERSION=2.1.143 sh packages/claude-code/bin/claude update --dry-run
- npm install -g --prefix /data/data/com.termux/files/usr/tmp/claude-2.1.143-aPapsm ./packages/claude-code