### PR TITLE
Bump GitHub Actions to Node 24-compatible releases

### DIFF
--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -21,13 +21,13 @@ jobs:
       BASE_BRANCH: dev
       REQUESTED_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || '@latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           ref: dev
           fetch-depth: 0
           persist-credentials: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -50,9 +50,9 @@ jobs:
       run:
         working-directory: packages/claude-code
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Update actions/checkout to v6.0.2 and actions/setup-node to v6.4.0.