### PR TITLE
Offset scheduled release watch timing

### DIFF
--- a/.github/workflows/claude-native-version-watch.yml
+++ b/.github/workflows/claude-native-version-watch.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: "@latest"
   schedule:
-    - cron: "0 19 * * *"
+    - cron: "7 19 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary\n- move GitHub watch from JST 04:00 to JST 04:07\n- keep local follow-up at a non-round minute (JST 04:41)\n\n## Verification\n- checked workflow cron value\n- checked local crontab