### PR TITLE
chore: bump version to 2.1.159-1

### DIFF
--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.159",
+  "version": "2.1.159-1",
   "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Bump package version to 2.1.159-1 for npm candidate publish