### PR TITLE
fix: package quality fixes for 2.1.159-2 candidate

### DIFF
--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -181,6 +181,13 @@
       "entry_js_offset": 223210916,
       "entry_end_offset": 238725072,
       "status": "termux_verified"
+    },
+    "2.1.159-1": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.159",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.159",
+      "entry_js_offset": 223232708,
+      "entry_end_offset": 238749397,
+      "status": "candidate"
     }
   }
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,22 +1,28 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.159-1",
-  "description": "Termux-native Claude Code wrapper with audited native replay",
+  "version": "2.1.159-2",
+  "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {
     "claude": "bin/claude"
   },
-  "scripts": {
-    "preinstall": "node lib/preinstall.js",
-    "postinstall": "node lib/postinstall.js"
-  },
+  "scripts": {},
   "files": [
-    "bin",
-    "lib",
-    "config",
+    "bin/",
+    "lib/",
+    "config/",
     "README.md"
   ],
   "engines": {
     "node": ">=18"
+  },
+  "keywords": [
+    "claude-code",
+    "termux",
+    "android",
+    "wrapper"
+  ],
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
package.json の lifecycle scripts を削除し、version を 2.1.159-2 に更新しました。あわせて packages/claude-code/config/claude-native-audited-versions.json に 2.1.159-1 candidate を追加しました。\n\n検証:\n- node で JSON parse 確認\n- git diff --check\n- npm pack --dry-run ./packages/claude-code