### PR TITLE
revert: remove unauthorized version bumps

### DIFF
--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -181,13 +181,6 @@
       "entry_js_offset": 223210916,
       "entry_end_offset": 238725072,
       "status": "termux_verified"
-    },
-    "2.1.159-1": {
-      "wrapper_spec": "@anthropic-ai/claude-code@2.1.159",
-      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.159",
-      "entry_js_offset": 223232708,
-      "entry_end_offset": 238749397,
-      "status": "candidate"
     }
   }
 }

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,28 +1,22 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.159-2",
-  "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
+  "version": "2.1.157",
+  "description": "Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {
     "claude": "bin/claude"
   },
-  "scripts": {},
+  "scripts": {
+    "preinstall": "node lib/preinstall.js",
+    "postinstall": "node lib/postinstall.js"
+  },
   "files": [
-    "bin/",
-    "lib/",
-    "config/",
+    "bin",
+    "lib",
+    "config",
     "README.md"
   ],
   "engines": {
     "node": ">=18"
-  },
-  "keywords": [
-    "claude-code",
-    "termux",
-    "android",
-    "wrapper"
-  ],
-  "publishConfig": {
-    "access": "public"
   }
 }


### PR DESCRIPTION
Reverts unauthorized commits a41b455, 442c869, 049e232. Returns package.json to 2.1.157, removes broken 2.1.159/2.1.159-1/2.1.159-2 changes. fix-print-mode-stdin is preserved.