### PR TITLE
fix: restore full Bun shim for 2.1.159 compatibility (2.1.159-3)

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -190,6 +190,15 @@
       "tarball_integrity": "sha512-c8dXbuQdrotGWll46GlnXm5IPpORK2VrBSosCmI6f8t7Snc/3F58fX0MbIjJ/ycXpY0aaKuOnufCuxf7wi1Xqw==",
       "tarball_sha256": "0b551634f11742310ba3b6344fb7912ba1ed8ee0ef4702eab0099d31b4eeb070",
       "status": "offset_discovered"
+    },
+    "2.1.159-3": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.159",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.159",
+      "entry_js_offset": 223232708,
+      "entry_end_offset": 238749397,
+      "tarball_integrity": "sha512-c8dXbuQdrotGWll46GlnXm5IPpORK2VrBSosCmI6f8t7Snc/3F58fX0MbIjJ/ycXpY0aaKuOnufCuxf7wi1Xqw==",
+      "tarball_sha256": "0b551634f11742310ba3b6344fb7912ba1ed8ee0ef4702eab0099d31b4eeb070",
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.157",
-  "latest_candidate_version": "2.1.159-2",
+  "latest_candidate_version": "2.1.159-3",
   "previous_stable_version": "2.1.153-4",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -190,6 +190,15 @@
       "tarball_integrity": "sha512-c8dXbuQdrotGWll46GlnXm5IPpORK2VrBSosCmI6f8t7Snc/3F58fX0MbIjJ/ycXpY0aaKuOnufCuxf7wi1Xqw==",
       "tarball_sha256": "0b551634f11742310ba3b6344fb7912ba1ed8ee0ef4702eab0099d31b4eeb070",
       "status": "offset_discovered"
+    },
+    "2.1.159-3": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.159",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.159",
+      "entry_js_offset": 223232708,
+      "entry_end_offset": 238749397,
+      "tarball_integrity": "sha512-c8dXbuQdrotGWll46GlnXm5IPpORK2VrBSosCmI6f8t7Snc/3F58fX0MbIjJ/ycXpY0aaKuOnufCuxf7wi1Xqw==",
+      "tarball_sha256": "0b551634f11742310ba3b6344fb7912ba1ed8ee0ef4702eab0099d31b4eeb070",
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.157",
-  "latest_candidate_version": "2.1.159-2",
+  "latest_candidate_version": "2.1.159-3",
   "previous_stable_version": "2.1.153-4",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -89,17 +89,6 @@ function ensureEntryFile() {
   return extractedFile;
 }
 
-function stringWidth(value) {
-  const text = String(value ?? '');
-  if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
-    const segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
-    let width = 0;
-    for (const _segment of segmenter.segment(text)) width += 1;
-    return width;
-  }
-  return Array.from(text).length;
-}
-
 function createFakeRequire(realRequire) {
   const realChild = realRequire('child_process');
 
@@ -156,6 +145,337 @@ function createFakeRequire(realRequire) {
   };
 }
 
+const ansiPattern =
+  /[\u001B\u009B][[\]()#;?]*(?:(?:(?:;[-a-zA-Z\d\/\#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d\/\#&.:=?%@~_]*)*)?(?:\u0007|\u001B\u005C|\u009C)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g;
+const ansiPatternSingle = new RegExp(ansiPattern.source);
+const debugBunShim = process.env.CLAUDE_TERMUX_DEBUG_BUN_SHIM === '1';
+
+function stripANSI(text) {
+  if (typeof text !== 'string' || text.length === 0) return '';
+  return text.replace(ansiPattern, '');
+}
+
+function codePointWidth(codePoint) {
+  if (
+    codePoint <= 0x1f ||
+    (codePoint >= 0x7f && codePoint <= 0x9f) ||
+    (codePoint >= 0x300 && codePoint <= 0x36f) ||
+    (codePoint >= 0x200b && codePoint <= 0x200f) ||
+    codePoint === 0xfeff ||
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f)
+  ) {
+    return 0;
+  }
+
+  if (
+    (codePoint >= 0x1100 && codePoint <= 0x115f) ||
+    (codePoint >= 0x2329 && codePoint <= 0x232a) ||
+    (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+    (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+    (codePoint >= 0x1f300 && codePoint <= 0x1faf8) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+  ) {
+    return 2;
+  }
+
+  return 1;
+}
+
+function stringWidth(value) {
+  const text = stripANSI(typeof value === 'string' ? value : String(value ?? ''));
+  let width = 0;
+  for (const char of text) {
+    const codePoint = char.codePointAt(0);
+    width += codePointWidth(codePoint);
+  }
+  return width;
+}
+
+function toHashBytes(value) {
+  if (Buffer.isBuffer(value)) return Buffer.from(value);
+  if (value instanceof Uint8Array) return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  if (value instanceof ArrayBuffer) return Buffer.from(value);
+  if (ArrayBuffer.isView(value)) {
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return Buffer.from(String(value ?? ''));
+}
+
+function hashValue(value, seed = 0) {
+  const FNV_OFFSET_BASIS_64 = 0xcbf29ce484222325n;
+  const FNV_PRIME_64 = 0x100000001b3n;
+  const MASK_64 = 0xffffffffffffffffn;
+
+  const seedNumber = typeof seed === 'bigint' ? Number(seed) : Number(seed);
+  const seedValue = Number.isFinite(seedNumber) ? Math.trunc(seedNumber) : 0;
+  let result = BigInt.asUintN(64, FNV_OFFSET_BASIS_64 ^ BigInt(seedValue));
+
+  const bytes = toHashBytes(value);
+  for (const byte of bytes) {
+    result ^= BigInt(byte);
+    result = (result * FNV_PRIME_64) & MASK_64;
+  }
+
+  return BigInt(result);
+}
+
+function which(cmd) {
+  const fs = require('fs');
+  const path = require('path');
+
+  if (typeof cmd !== 'string' || cmd.length === 0) return null;
+
+  const isExecutable = candidate => {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      const stat = fs.statSync(candidate);
+      return stat.isFile();
+    } catch {
+      return false;
+    }
+  };
+
+  if (cmd.includes(path.sep)) {
+    return isExecutable(cmd) ? path.resolve(cmd) : null;
+  }
+
+  const searchPath = process.env.PATH || '';
+  for (const entry of searchPath.split(path.delimiter)) {
+    if (!entry) continue;
+    const candidate = path.join(entry, cmd);
+    if (isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+function wrapAnsi(str, columns, options) {
+  const input = typeof str === 'string' ? str : String(str ?? '');
+  const widthLimit = Number(columns);
+  if (!Number.isFinite(widthLimit) || widthLimit <= 0) return input;
+
+  const wordWrap = !options || options.wordWrap !== false;
+  const hard = !!(options && options.hard);
+
+  if (!wordWrap || hard) {
+    const result = [];
+    let width = 0;
+
+    for (let i = 0; i < input.length; ) {
+      const char = input[i];
+
+      if (char === '\u001b' || char === '\u009b') {
+        const match = input.slice(i).match(ansiPatternSingle);
+        if (match && match.index === 0) {
+          result.push(match[0]);
+          i += match[0].length;
+          continue;
+        }
+      }
+
+      if (char === '\n') {
+        result.push(char);
+        width = 0;
+        i += 1;
+        continue;
+      }
+
+      const codePoint = input.codePointAt(i);
+      const charText = String.fromCodePoint(codePoint);
+      const charWidth = codePointWidth(codePoint);
+
+      if (width > 0 && width + charWidth > widthLimit) {
+        result.push('\n');
+        width = 0;
+      }
+
+      result.push(charText);
+      width += charWidth;
+      i += charText.length;
+    }
+
+    return result.join('');
+  }
+
+  const result = [];
+  let line = '';
+  let lineWidth = 0;
+  let pendingSpaces = '';
+
+  for (let i = 0; i < input.length; ) {
+    const char = input[i];
+
+    if (char === '\u001b' || char === '\u009b') {
+      const match = input.slice(i).match(ansiPatternSingle);
+      if (match && match.index === 0) {
+        line += match[0];
+        i += match[0].length;
+        continue;
+      }
+    }
+
+    if (char === '\n') {
+      if (line.length > 0) result.push(line);
+      result.push('\n');
+      line = '';
+      lineWidth = 0;
+      pendingSpaces = '';
+      i += 1;
+      continue;
+    }
+
+    const codePoint = input.codePointAt(i);
+    const charText = String.fromCodePoint(codePoint);
+    if (charText === ' ' || charText === '\t') {
+      pendingSpaces += charText;
+      i += charText.length;
+      continue;
+    }
+
+    let end = i + charText.length;
+    while (end < input.length) {
+      const nextChar = input[end];
+      if (nextChar === '\n' || nextChar === ' ' || nextChar === '\t' || nextChar === '\u001b' || nextChar === '\u009b') {
+        break;
+      }
+      const nextCodePoint = input.codePointAt(end);
+      end += String.fromCodePoint(nextCodePoint).length;
+    }
+
+    const text = input.slice(i, end);
+    const textWidth = stringWidth(text);
+    const pendingWidth = pendingSpaces ? stringWidth(pendingSpaces) : 0;
+
+    if (lineWidth > 0 && lineWidth + pendingWidth + textWidth > widthLimit) {
+      result.push(line);
+      result.push('\n');
+      line = '';
+      lineWidth = 0;
+      pendingSpaces = '';
+    }
+
+    if (lineWidth > 0 && pendingSpaces) {
+      line += pendingSpaces;
+      lineWidth += pendingWidth;
+    }
+    pendingSpaces = '';
+
+    line += text;
+    lineWidth += textWidth;
+    i = end;
+  }
+
+  if (pendingSpaces && lineWidth > 0) {
+    line += pendingSpaces;
+  }
+  if (line.length > 0) result.push(line);
+
+  return result.join('');
+}
+
+const YAML = {
+  parse(text) {
+    try {
+      const lines = String(text).split('\n');
+      const result = {};
+      for (const line of lines) {
+        const m = line.match(/^([^:#]+):\s*(.*)$/);
+        if (m) result[m[1].trim()] = m[2].trim().replace(/^['"]|['"]$/g, '');
+      }
+      return result;
+    } catch { return {}; }
+  },
+  stringify(obj) {
+    try {
+      return Object.entries(obj || {}).map(([k, v]) => k + ': ' + v).join('\n') + '\n';
+    } catch { return ''; }
+  },
+};
+
+function parseSemverVersion(value) {
+  const text = String(value ?? '').trim().replace(/^[v=]/, '');
+  const match = text.match(/^(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/);
+  if (!match) return null;
+  return {
+    parts: [match[1], match[2] ?? '0', match[3] ?? '0'].map(Number),
+    pre: match[4] ? match[4].split('.') : null,
+  };
+}
+
+function comparePrerelease(a, b) {
+  const size = Math.max(a.length, b.length);
+  for (let i = 0; i < size; i++) {
+    if (a[i] === undefined) return -1;
+    if (b[i] === undefined) return 1;
+    const aNum = /^\d+$/.test(a[i]);
+    const bNum = /^\d+$/.test(b[i]);
+    if (aNum && bNum) { const d = Number(a[i]) - Number(b[i]); if (d) return d < 0 ? -1 : 1; }
+    else if (aNum) return -1;
+    else if (bNum) return 1;
+    else if (a[i] < b[i]) return -1;
+    else if (a[i] > b[i]) return 1;
+  }
+  return 0;
+}
+
+const semver = {
+  order(left, right) {
+    const a = parseSemverVersion(left), b = parseSemverVersion(right);
+    if (!a || !b) return NaN;
+    for (let i = 0; i < 3; i++) {
+      const d = a.parts[i] - b.parts[i];
+      if (d) return d < 0 ? -1 : 1;
+    }
+    if (a.pre && !b.pre) return -1;
+    if (!a.pre && b.pre) return 1;
+    if (a.pre && b.pre) return comparePrerelease(a.pre, b.pre);
+    return 0;
+  },
+  satisfies(version, range) {
+    if (!version || !range) return false;
+    const v = String(version).replace(/^[v=]/, '');
+    const clean = String(range).trim();
+    if (!clean) return false;
+    if (clean.includes('||')) return clean.split('||').some(r => semver.satisfies(v, r.trim()));
+    const parts = clean.split(/\s+/).filter(Boolean);
+    if (parts.length > 1) return parts.every(p => semver.satisfies(v, p));
+    const caret = clean.match(/^\^([0-9].*)$/);
+    if (caret) {
+      const p = parseSemverVersion(caret[1]);
+      if (!p) return false;
+      const upper = p.parts[0] > 0 ? (p.parts[0] + 1) + '.0.0'
+        : p.parts[1] > 0 ? '0.' + (p.parts[1] + 1) + '.0'
+        : '0.0.' + (p.parts[2] + 1);
+      return semver.satisfies(v, '>=' + caret[1]) && semver.satisfies(v, '<' + upper);
+    }
+    const tilde = clean.match(/^~([0-9].*)$/);
+    if (tilde) {
+      const p = parseSemverVersion(tilde[1]);
+      if (!p) return false;
+      const original = tilde[1].split('.');
+      const upper = original.length >= 2
+        ? p.parts[0] + '.' + (p.parts[1] + 1) + '.0'
+        : (p.parts[0] + 1) + '.0.0';
+      return semver.satisfies(v, '>=' + tilde[1]) && semver.satisfies(v, '<' + upper);
+    }
+    const m = clean.match(/^([><=!]{1,2})\s*([0-9].*)$/);
+    if (m) {
+      const cmp = semver.order(v, m[2]);
+      if (!Number.isFinite(cmp)) return false;
+      return m[1] === '>=' ? cmp >= 0 : m[1] === '>' ? cmp > 0 :
+             m[1] === '<=' ? cmp <= 0 : m[1] === '<' ? cmp < 0 :
+             m[1] === '=' || m[1] === '==' ? cmp === 0 : m[1] === '!=' ? cmp !== 0 : false;
+    }
+    const exact = parseSemverVersion(clean);
+    return exact ? semver.order(v, clean) === 0 : false;
+  },
+};
+
+
 async function main() {
   const extractedFile = ensureEntryFile();
   const code = fs.readFileSync(extractedFile, 'utf8');
@@ -177,7 +497,33 @@ async function main() {
     process.once('uncaughtException', onAsyncError);
     process.once('unhandledRejection', onAsyncError);
     Object.defineProperty(process.versions, 'bun', { value: '1.1.8', configurable: true });
-    globalThis.Bun = { version: '1.1.8', stringWidth };
+    const BunShim = {
+      version: '1.1.8',
+      stringWidth,
+      hash: hashValue,
+      which,
+      wrapAnsi,
+      stripANSI,
+      semver,
+      YAML,
+      gc: (sync) => {
+        try {
+          if (typeof global.gc === 'function') global.gc(sync === false ? false : true);
+        } catch {}
+      },
+      stdin: { stream: null },
+      embeddedFiles: [],
+    };
+    const BunProxy = new Proxy(BunShim, {
+      get(target, key, receiver) {
+        if (!(key in target) && typeof key !== 'symbol' && debugBunShim) {
+          console.error('[BunShim missing]', key);
+        }
+        return Reflect.get(target, key, receiver);
+      },
+    });
+    globalThis.Bun = BunProxy;
+
     process.argv = ['node', extractedFile, ...argv];
     process.exit = code => {
       throw new RequestedExit(code);
@@ -264,17 +610,6 @@ function ensureEntryFile() {
   return extractedFile;
 }
 
-function stringWidth(value) {
-  const text = String(value ?? '');
-  if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
-    const segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
-    let width = 0;
-    for (const _segment of segmenter.segment(text)) width += 1;
-    return width;
-  }
-  return Array.from(text).length;
-}
-
 function createFakeRequire(realRequire) {
   const realChild = realRequire('child_process');
 
@@ -331,6 +666,337 @@ function createFakeRequire(realRequire) {
   };
 }
 
+const ansiPattern =
+  /[\u001B\u009B][[\]()#;?]*(?:(?:(?:;[-a-zA-Z\d\/\#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d\/\#&.:=?%@~_]*)*)?(?:\u0007|\u001B\u005C|\u009C)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g;
+const ansiPatternSingle = new RegExp(ansiPattern.source);
+const debugBunShim = process.env.CLAUDE_TERMUX_DEBUG_BUN_SHIM === '1';
+
+function stripANSI(text) {
+  if (typeof text !== 'string' || text.length === 0) return '';
+  return text.replace(ansiPattern, '');
+}
+
+function codePointWidth(codePoint) {
+  if (
+    codePoint <= 0x1f ||
+    (codePoint >= 0x7f && codePoint <= 0x9f) ||
+    (codePoint >= 0x300 && codePoint <= 0x36f) ||
+    (codePoint >= 0x200b && codePoint <= 0x200f) ||
+    codePoint === 0xfeff ||
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f)
+  ) {
+    return 0;
+  }
+
+  if (
+    (codePoint >= 0x1100 && codePoint <= 0x115f) ||
+    (codePoint >= 0x2329 && codePoint <= 0x232a) ||
+    (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+    (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+    (codePoint >= 0x1f300 && codePoint <= 0x1faf8) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+  ) {
+    return 2;
+  }
+
+  return 1;
+}
+
+function stringWidth(value) {
+  const text = stripANSI(typeof value === 'string' ? value : String(value ?? ''));
+  let width = 0;
+  for (const char of text) {
+    const codePoint = char.codePointAt(0);
+    width += codePointWidth(codePoint);
+  }
+  return width;
+}
+
+function toHashBytes(value) {
+  if (Buffer.isBuffer(value)) return Buffer.from(value);
+  if (value instanceof Uint8Array) return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  if (value instanceof ArrayBuffer) return Buffer.from(value);
+  if (ArrayBuffer.isView(value)) {
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return Buffer.from(String(value ?? ''));
+}
+
+function hashValue(value, seed = 0) {
+  const FNV_OFFSET_BASIS_64 = 0xcbf29ce484222325n;
+  const FNV_PRIME_64 = 0x100000001b3n;
+  const MASK_64 = 0xffffffffffffffffn;
+
+  const seedNumber = typeof seed === 'bigint' ? Number(seed) : Number(seed);
+  const seedValue = Number.isFinite(seedNumber) ? Math.trunc(seedNumber) : 0;
+  let result = BigInt.asUintN(64, FNV_OFFSET_BASIS_64 ^ BigInt(seedValue));
+
+  const bytes = toHashBytes(value);
+  for (const byte of bytes) {
+    result ^= BigInt(byte);
+    result = (result * FNV_PRIME_64) & MASK_64;
+  }
+
+  return BigInt(result);
+}
+
+function which(cmd) {
+  const fs = require('fs');
+  const path = require('path');
+
+  if (typeof cmd !== 'string' || cmd.length === 0) return null;
+
+  const isExecutable = candidate => {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      const stat = fs.statSync(candidate);
+      return stat.isFile();
+    } catch {
+      return false;
+    }
+  };
+
+  if (cmd.includes(path.sep)) {
+    return isExecutable(cmd) ? path.resolve(cmd) : null;
+  }
+
+  const searchPath = process.env.PATH || '';
+  for (const entry of searchPath.split(path.delimiter)) {
+    if (!entry) continue;
+    const candidate = path.join(entry, cmd);
+    if (isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+function wrapAnsi(str, columns, options) {
+  const input = typeof str === 'string' ? str : String(str ?? '');
+  const widthLimit = Number(columns);
+  if (!Number.isFinite(widthLimit) || widthLimit <= 0) return input;
+
+  const wordWrap = !options || options.wordWrap !== false;
+  const hard = !!(options && options.hard);
+
+  if (!wordWrap || hard) {
+    const result = [];
+    let width = 0;
+
+    for (let i = 0; i < input.length; ) {
+      const char = input[i];
+
+      if (char === '\u001b' || char === '\u009b') {
+        const match = input.slice(i).match(ansiPatternSingle);
+        if (match && match.index === 0) {
+          result.push(match[0]);
+          i += match[0].length;
+          continue;
+        }
+      }
+
+      if (char === '\n') {
+        result.push(char);
+        width = 0;
+        i += 1;
+        continue;
+      }
+
+      const codePoint = input.codePointAt(i);
+      const charText = String.fromCodePoint(codePoint);
+      const charWidth = codePointWidth(codePoint);
+
+      if (width > 0 && width + charWidth > widthLimit) {
+        result.push('\n');
+        width = 0;
+      }
+
+      result.push(charText);
+      width += charWidth;
+      i += charText.length;
+    }
+
+    return result.join('');
+  }
+
+  const result = [];
+  let line = '';
+  let lineWidth = 0;
+  let pendingSpaces = '';
+
+  for (let i = 0; i < input.length; ) {
+    const char = input[i];
+
+    if (char === '\u001b' || char === '\u009b') {
+      const match = input.slice(i).match(ansiPatternSingle);
+      if (match && match.index === 0) {
+        line += match[0];
+        i += match[0].length;
+        continue;
+      }
+    }
+
+    if (char === '\n') {
+      if (line.length > 0) result.push(line);
+      result.push('\n');
+      line = '';
+      lineWidth = 0;
+      pendingSpaces = '';
+      i += 1;
+      continue;
+    }
+
+    const codePoint = input.codePointAt(i);
+    const charText = String.fromCodePoint(codePoint);
+    if (charText === ' ' || charText === '\t') {
+      pendingSpaces += charText;
+      i += charText.length;
+      continue;
+    }
+
+    let end = i + charText.length;
+    while (end < input.length) {
+      const nextChar = input[end];
+      if (nextChar === '\n' || nextChar === ' ' || nextChar === '\t' || nextChar === '\u001b' || nextChar === '\u009b') {
+        break;
+      }
+      const nextCodePoint = input.codePointAt(end);
+      end += String.fromCodePoint(nextCodePoint).length;
+    }
+
+    const text = input.slice(i, end);
+    const textWidth = stringWidth(text);
+    const pendingWidth = pendingSpaces ? stringWidth(pendingSpaces) : 0;
+
+    if (lineWidth > 0 && lineWidth + pendingWidth + textWidth > widthLimit) {
+      result.push(line);
+      result.push('\n');
+      line = '';
+      lineWidth = 0;
+      pendingSpaces = '';
+    }
+
+    if (lineWidth > 0 && pendingSpaces) {
+      line += pendingSpaces;
+      lineWidth += pendingWidth;
+    }
+    pendingSpaces = '';
+
+    line += text;
+    lineWidth += textWidth;
+    i = end;
+  }
+
+  if (pendingSpaces && lineWidth > 0) {
+    line += pendingSpaces;
+  }
+  if (line.length > 0) result.push(line);
+
+  return result.join('');
+}
+
+const YAML = {
+  parse(text) {
+    try {
+      const lines = String(text).split('\n');
+      const result = {};
+      for (const line of lines) {
+        const m = line.match(/^([^:#]+):\s*(.*)$/);
+        if (m) result[m[1].trim()] = m[2].trim().replace(/^['"]|['"]$/g, '');
+      }
+      return result;
+    } catch { return {}; }
+  },
+  stringify(obj) {
+    try {
+      return Object.entries(obj || {}).map(([k, v]) => k + ': ' + v).join('\n') + '\n';
+    } catch { return ''; }
+  },
+};
+
+function parseSemverVersion(value) {
+  const text = String(value ?? '').trim().replace(/^[v=]/, '');
+  const match = text.match(/^(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/);
+  if (!match) return null;
+  return {
+    parts: [match[1], match[2] ?? '0', match[3] ?? '0'].map(Number),
+    pre: match[4] ? match[4].split('.') : null,
+  };
+}
+
+function comparePrerelease(a, b) {
+  const size = Math.max(a.length, b.length);
+  for (let i = 0; i < size; i++) {
+    if (a[i] === undefined) return -1;
+    if (b[i] === undefined) return 1;
+    const aNum = /^\d+$/.test(a[i]);
+    const bNum = /^\d+$/.test(b[i]);
+    if (aNum && bNum) { const d = Number(a[i]) - Number(b[i]); if (d) return d < 0 ? -1 : 1; }
+    else if (aNum) return -1;
+    else if (bNum) return 1;
+    else if (a[i] < b[i]) return -1;
+    else if (a[i] > b[i]) return 1;
+  }
+  return 0;
+}
+
+const semver = {
+  order(left, right) {
+    const a = parseSemverVersion(left), b = parseSemverVersion(right);
+    if (!a || !b) return NaN;
+    for (let i = 0; i < 3; i++) {
+      const d = a.parts[i] - b.parts[i];
+      if (d) return d < 0 ? -1 : 1;
+    }
+    if (a.pre && !b.pre) return -1;
+    if (!a.pre && b.pre) return 1;
+    if (a.pre && b.pre) return comparePrerelease(a.pre, b.pre);
+    return 0;
+  },
+  satisfies(version, range) {
+    if (!version || !range) return false;
+    const v = String(version).replace(/^[v=]/, '');
+    const clean = String(range).trim();
+    if (!clean) return false;
+    if (clean.includes('||')) return clean.split('||').some(r => semver.satisfies(v, r.trim()));
+    const parts = clean.split(/\s+/).filter(Boolean);
+    if (parts.length > 1) return parts.every(p => semver.satisfies(v, p));
+    const caret = clean.match(/^\^([0-9].*)$/);
+    if (caret) {
+      const p = parseSemverVersion(caret[1]);
+      if (!p) return false;
+      const upper = p.parts[0] > 0 ? (p.parts[0] + 1) + '.0.0'
+        : p.parts[1] > 0 ? '0.' + (p.parts[1] + 1) + '.0'
+        : '0.0.' + (p.parts[2] + 1);
+      return semver.satisfies(v, '>=' + caret[1]) && semver.satisfies(v, '<' + upper);
+    }
+    const tilde = clean.match(/^~([0-9].*)$/);
+    if (tilde) {
+      const p = parseSemverVersion(tilde[1]);
+      if (!p) return false;
+      const original = tilde[1].split('.');
+      const upper = original.length >= 2
+        ? p.parts[0] + '.' + (p.parts[1] + 1) + '.0'
+        : (p.parts[0] + 1) + '.0.0';
+      return semver.satisfies(v, '>=' + tilde[1]) && semver.satisfies(v, '<' + upper);
+    }
+    const m = clean.match(/^([><=!]{1,2})\s*([0-9].*)$/);
+    if (m) {
+      const cmp = semver.order(v, m[2]);
+      if (!Number.isFinite(cmp)) return false;
+      return m[1] === '>=' ? cmp >= 0 : m[1] === '>' ? cmp > 0 :
+             m[1] === '<=' ? cmp <= 0 : m[1] === '<' ? cmp < 0 :
+             m[1] === '=' || m[1] === '==' ? cmp === 0 : m[1] === '!=' ? cmp !== 0 : false;
+    }
+    const exact = parseSemverVersion(clean);
+    return exact ? semver.order(v, clean) === 0 : false;
+  },
+};
+
+
 async function main() {
   const extractedFile = ensureEntryFile();
   const code = fs.readFileSync(extractedFile, 'utf8');
@@ -352,7 +1018,33 @@ async function main() {
     process.once('uncaughtException', onAsyncError);
     process.once('unhandledRejection', onAsyncError);
     Object.defineProperty(process.versions, 'bun', { value: '1.1.8', configurable: true });
-    globalThis.Bun = { version: '1.1.8', stringWidth };
+    const BunShim = {
+      version: '1.1.8',
+      stringWidth,
+      hash: hashValue,
+      which,
+      wrapAnsi,
+      stripANSI,
+      semver,
+      YAML,
+      gc: (sync) => {
+        try {
+          if (typeof global.gc === 'function') global.gc(sync === false ? false : true);
+        } catch {}
+      },
+      stdin: { stream: null },
+      embeddedFiles: [],
+    };
+    const BunProxy = new Proxy(BunShim, {
+      get(target, key, receiver) {
+        if (!(key in target) && typeof key !== 'symbol' && debugBunShim) {
+          console.error('[BunShim missing]', key);
+        }
+        return Reflect.get(target, key, receiver);
+      },
+    });
+    globalThis.Bun = BunProxy;
+
     process.argv = ['node', extractedFile, ...argv];
     process.exit = code => {
       throw new RequestedExit(code);

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.159-2",
+  "version": "2.1.159-3",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Restores complete Bun shim (stripANSI/codePointWidth/wrapAnsi/semver/YAML/BunProxy) to both -p helper and normal helper paths. Bumps to 2.1.159-3.