### PR TITLE
fix: add process.exit() after main() to handle dangling handles (2.1.159-4)

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -199,6 +199,15 @@
       "tarball_integrity": "sha512-c8dXbuQdrotGWll46GlnXm5IPpORK2VrBSosCmI6f8t7Snc/3F58fX0MbIjJ/ycXpY0aaKuOnufCuxf7wi1Xqw==",
       "tarball_sha256": "0b551634f11742310ba3b6344fb7912ba1ed8ee0ef4702eab0099d31b4eeb070",
       "status": "offset_discovered"
+    },
+    "2.1.159-4": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.159",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.159",
+      "entry_js_offset": 223232708,
+      "entry_end_offset": 238749397,
+      "tarball_integrity": "sha512-c8dXbuQdrotGWll46GlnXm5IPpORK2VrBSosCmI6f8t7Snc/3F58fX0MbIjJ/ycXpY0aaKuOnufCuxf7wi1Xqw==",
+      "tarball_sha256": "0b551634f11742310ba3b6344fb7912ba1ed8ee0ef4702eab0099d31b4eeb070",
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.157",
-  "latest_candidate_version": "2.1.159-3",
+  "latest_candidate_version": "2.1.159-4",
   "previous_stable_version": "2.1.153-4",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -199,6 +199,15 @@
       "tarball_integrity": "sha512-c8dXbuQdrotGWll46GlnXm5IPpORK2VrBSosCmI6f8t7Snc/3F58fX0MbIjJ/ycXpY0aaKuOnufCuxf7wi1Xqw==",
       "tarball_sha256": "0b551634f11742310ba3b6344fb7912ba1ed8ee0ef4702eab0099d31b4eeb070",
       "status": "offset_discovered"
+    },
+    "2.1.159-4": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.159",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.159",
+      "entry_js_offset": 223232708,
+      "entry_end_offset": 238749397,
+      "tarball_integrity": "sha512-c8dXbuQdrotGWll46GlnXm5IPpORK2VrBSosCmI6f8t7Snc/3F58fX0MbIjJ/ycXpY0aaKuOnufCuxf7wi1Xqw==",
+      "tarball_sha256": "0b551634f11742310ba3b6344fb7912ba1ed8ee0ef4702eab0099d31b4eeb070",
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.157",
-  "latest_candidate_version": "2.1.159-3",
+  "latest_candidate_version": "2.1.159-4",
   "previous_stable_version": "2.1.153-4",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -557,7 +557,9 @@ async function main() {
   }
 }
 
-main().catch(error => {
+main().then(() => {
+  process.exit(process.exitCode ?? 0);
+}).catch(error => {
   if (error && error.code === 'CLAUDE_TERMUX_OFFICIAL_UPDATE_BLOCKED') {
     console.error(BLOCK_MESSAGE);
     process.exit(error.status || 1);
@@ -1078,7 +1080,9 @@ async function main() {
   }
 }
 
-main().catch(error => {
+main().then(() => {
+  process.exit(process.exitCode ?? 0);
+}).catch(error => {
   if (error && error.code === 'CLAUDE_TERMUX_OFFICIAL_UPDATE_BLOCKED') {
     console.error(BLOCK_MESSAGE);
     process.exit(error.status || 1);

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.159-3",
+  "version": "2.1.159-4",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Root cause: 33 active handles (TLSSocket, StatWatcher, timers) remain after fn() execution in 2.1.159, preventing event loop exit. Fix: add main().then(() => process.exit(exitCode)) to both -p helper and normal helper paths. Also restores full Bun shim from 2.1.157.