### PR TITLE
fix: correct version table — 2.1.179 as rollback, 2.1.178 as historical stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Only versions registered in the audited metadata can run.
 | Version | Status |
 |---------|--------|
 | `2.1.181` | ✅ **Recommended / 推奨** — current audited release |
-| `2.1.178` | ✅ historical stable — rollback candidate |
+| `2.1.179` | ✅ historical stable — rollback candidate |
+| `2.1.178` | ✅ historical stable |
 | `2.1.161-2` | ✅ historical stable |
 | `2.1.161-1` | reverted — do not keep using this line |
 | `2.1.161` | reverted — do not keep using this line |

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -3,6 +3,6 @@
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.181",
   "latest_candidate_version": "2.1.181",
-  "previous_stable_version": "2.1.178",
+  "previous_stable_version": "2.1.179",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -310,7 +310,7 @@
       "entry_end_offset": 228336440,
       "tarball_integrity": "sha512-Xjf3hWeqQ2G3uu+XcOLmqCT4ZbLVsHSohWO4My9XH3NUQaXYoziqU+UWxZx9LGBrNVzckkagznNB0WxG2SY0qA==",
       "tarball_sha256": "0745632d28ebf52f4c8056516a461ef4f5457add7dd035f8225e33a3c62249ee",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/scripts/update-readme-version-guidance.js
+++ b/scripts/update-readme-version-guidance.js
@@ -85,12 +85,32 @@ function updateSupportedVersionsTable(content, latestAudited, previousStable) {
     `| \`${latestAudited}\` | ✅ **Recommended / 推奨** — current audited release |`
   );
 
-  // Replace the rollback candidate row version
+  // Replace the rollback candidate row version, and demote old rollback to historical stable
   if (previousStable) {
+    const rollbackMatches = [...tableSection.matchAll(/\| `([^`]+)` \| ✅ historical stable — rollback candidate \|/g)];
+    if (rollbackMatches.length === 0) throw new Error('no rollback candidate row found');
+    if (rollbackMatches.length > 1) throw new Error(`multiple rollback candidate rows: ${rollbackMatches.map(m => m[1]).join(', ')}`);
+    const currentRollback = rollbackMatches[0][1];
+    const escapedPrev = previousStable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    tableSection = tableSection.replace(`| \`${escapedPrev}\` | ✅ historical stable |\n`, '');
     tableSection = tableSection.replace(
       /\| `[^`]+` \| ✅ historical stable — rollback candidate \|/,
       `| \`${previousStable}\` | ✅ historical stable — rollback candidate |`
     );
+    if (currentRollback !== previousStable && !tableSection.includes(`| \`${currentRollback}\` |`)) {
+      const firstHistoricalMatch = tableSection.match(/\| `[^`]+` \| ✅ historical stable \|/);
+      if (firstHistoricalMatch) {
+        tableSection = tableSection.replace(
+          firstHistoricalMatch[0],
+          `| \`${currentRollback}\` | ✅ historical stable |\n${firstHistoricalMatch[0]}`
+        );
+      } else {
+        tableSection = tableSection.replace(
+          `| \`${previousStable}\` | ✅ historical stable — rollback candidate |`,
+          `| \`${previousStable}\` | ✅ historical stable — rollback candidate |\n| \`${currentRollback}\` | ✅ historical stable |`
+        );
+      }
+    }
   }
 
   return content.slice(0, startIdx + tableStart.length) + tableSection + content.slice(endIdx);
@@ -242,3 +262,5 @@ try {
   console.error(error && error.stack ? error.stack : String(error));
   process.exit(1);
 }
+
+if (require.main !== module) { module.exports = { updateSupportedVersionsTable }; }


### PR DESCRIPTION
Fixes:
- previous_stable_version: 2.1.178 → 2.1.179 in manifest
- packages/.../claude-native-audited-versions.json: 2.1.181 offset_discovered → termux_verified
- updateSupportedVersionsTable(): demote old rollback candidate to historical stable on promotion
- Run script to update README.md and packages/claude-code/README.md

Result:
| 2.1.181 | Recommended |
| 2.1.179 | historical stable — rollback candidate |
| 2.1.178 | historical stable |