### PR TITLE
fix: replace historical stable row instead of insert, remove duplicate 2.1.161-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Only versions registered in the audited metadata can run.
 | `2.1.181` | ✅ **Recommended / 推奨** — current audited release |
 | `2.1.179` | ✅ historical stable — rollback candidate |
 | `2.1.178` | ✅ historical stable |
-| `2.1.161-2` | ✅ historical stable |
 | `2.1.161-1` | reverted — do not keep using this line |
 | `2.1.161` | reverted — do not keep using this line |
 | `2.1.157` | historical — not recommended for new installs |

--- a/scripts/update-readme-version-guidance.js
+++ b/scripts/update-readme-version-guidance.js
@@ -102,7 +102,7 @@ function updateSupportedVersionsTable(content, latestAudited, previousStable) {
       if (firstHistoricalMatch) {
         tableSection = tableSection.replace(
           firstHistoricalMatch[0],
-          `| \`${currentRollback}\` | ✅ historical stable |\n${firstHistoricalMatch[0]}`
+          `| \`${currentRollback}\` | ✅ historical stable |`
         );
       } else {
         tableSection = tableSection.replace(


### PR DESCRIPTION
Fixes updateSupportedVersionsTable() to REPLACE existing historical stable row instead of inserting before it. Removes the duplicate 2.1.161-2 row added by the previous fix. Result: table stays at 3 rows (Recommended / rollback candidate / historical stable) on every release.