### PR TITLE
fix: notify owner via email when new claude-code version detected

### DIFF
--- a/.github/workflows/claude-code-version-watch.yml
+++ b/.github/workflows/claude-code-version-watch.yml
@@ -107,5 +107,6 @@ jobs:
               --base main \
               --head "$branch" \
               --title "Track claude-code ${version} candidate" \
+              --reviewer bash0816 \
               --body "$(printf 'Automated upstream claude-code intake.\n\n- upstream: @anthropic-ai/claude-code@%s\n- status: offset_discovered\n- Next: Device B verification -> promote-verified-version.js -> npm publish' "$version")"
           fi


### PR DESCRIPTION
Watch が新バージョンを検出して PR を作る際に --reviewer bash0816 を追加。これによりオーナーにレビュー依頼メールが届くようになる。