### PR TITLE
fix: remove manual approval gate from promote-and-publish workflow

### DIFF
--- a/.github/workflows/promote-and-publish.yml
+++ b/.github/workflows/promote-and-publish.yml
@@ -29,7 +29,6 @@ jobs:
   promote:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: npm-publish
     env:
       GH_TOKEN: ${{ github.token }}
     steps:


### PR DESCRIPTION
promote-and-publish.yml は termux_verified チェックで安全性を担保しているため、environment の手動承認ゲートは不要。NPM_TOKEN はリポジトリレベル secret のため environment なしでも参照可能。