### PR TITLE
Track claude-code 2.1.191 candidate

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -356,6 +356,15 @@
       "tarball_integrity": "sha512-vi7UxnBZTTukCDHa18ubpUHrsdsoMaK5saIr93abc3tMumBHUZqE/WScJb5/Ct9Go38xFDrfeRVpdIPZVTzUzA==",
       "tarball_sha256": "ece8776faa8641c0670585a288793104f6648dcd0c1f067d22ad013c83cbb2f5",
       "status": "termux_verified"
+    },
+    "2.1.191": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.191",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.191",
+      "entry_js_offset": 217041140,
+      "entry_end_offset": 234464001,
+      "tarball_integrity": "sha512-i9rmqPRTqkHoZxKjx3DutEZN3g/0ecSd1OYmJn01FOcKsT0Xyc9VCyta0dStTqDYD+9Oj3AhXaooxn1DuK9rMA==",
+      "tarball_sha256": "91716b6a342feb68f8538a41e67231722910e4f75f76fde552ec4ca051e442d8",
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.187",
-  "latest_candidate_version": "2.1.187",
+  "latest_candidate_version": "2.1.191",
   "previous_stable_version": "2.1.186",
   "stable_pinned_version": "2.1.176",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -356,6 +356,15 @@
       "tarball_integrity": "sha512-vi7UxnBZTTukCDHa18ubpUHrsdsoMaK5saIr93abc3tMumBHUZqE/WScJb5/Ct9Go38xFDrfeRVpdIPZVTzUzA==",
       "tarball_sha256": "ece8776faa8641c0670585a288793104f6648dcd0c1f067d22ad013c83cbb2f5",
       "status": "termux_verified"
+    },
+    "2.1.191": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.191",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.191",
+      "entry_js_offset": 217041140,
+      "entry_end_offset": 234464001,
+      "tarball_integrity": "sha512-i9rmqPRTqkHoZxKjx3DutEZN3g/0ecSd1OYmJn01FOcKsT0Xyc9VCyta0dStTqDYD+9Oj3AhXaooxn1DuK9rMA==",
+      "tarball_sha256": "91716b6a342feb68f8538a41e67231722910e4f75f76fde552ec4ca051e442d8",
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.187",
-  "latest_candidate_version": "2.1.187",
+  "latest_candidate_version": "2.1.191",
   "previous_stable_version": "2.1.186",
   "stable_pinned_version": "2.1.176",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -558,7 +558,7 @@ function rewriteNativeChunkSource(source) {
     /\btypeof Bun\b/g,
     'typeof __claudeBun',
     'typeof Bun',
-    3,
+    4,
   );
   patched = replaceRequired(
     patched,
@@ -579,7 +579,7 @@ function rewriteNativeChunkSource(source) {
     /\bBun\./g,
     '__claudeBun.',
     'Bun property access',
-    34,
+    36,
   );
   patched = replaceRequired(
     patched,
@@ -1229,7 +1229,7 @@ function rewriteNativeChunkSource(source) {
     /\btypeof Bun\b/g,
     'typeof __claudeBun',
     'typeof Bun',
-    3,
+    4,
   );
   patched = replaceRequired(
     patched,
@@ -1250,7 +1250,7 @@ function rewriteNativeChunkSource(source) {
     /\bBun\./g,
     '__claudeBun.',
     'Bun property access',
-    34,
+    36,
   );
   patched = replaceRequired(
     patched,

--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -278,8 +278,8 @@ test('cleanupStaleEntryFiles removes only stale extracted files for the same off
 });
 
 function buildSyntheticBundleSource() {
-  const typeofBun = Array.from({ length: 3 }, () => 'typeof Bun').join('; ');
-  const bunProps = Array.from({ length: 34 }, (_, index) => `Bun.p${index}`).join('; ');
+  const typeofBun = Array.from({ length: 4 }, () => 'typeof Bun').join('; ');
+  const bunProps = Array.from({ length: 36 }, (_, index) => `Bun.p${index}`).join('; ');
   return `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0 }`;
 }
 
@@ -303,11 +303,12 @@ test('rewriteNativeChunkSource rejects unexpected replacement counts', () => {
 
   assert.throws(
     () => rewriteNativeChunkSource(source),
-    /unexpected Bun property access count 33/,
+    /unexpected Bun property access count 35/,
   );
 });
 
-const tarballPath = path.join(__dirname, '..', 'bash0816-claude-code-2.1.177.tgz');
+const packageVersion = require('../package.json').version;
+const tarballPath = path.join(__dirname, '..', `bash0816-claude-code-${packageVersion}.tgz`);
 
 test('tarball contents match the workspace runner and test file', { skip: !fs.existsSync(tarballPath) }, () => {
   const tarRunner = child_process.execFileSync('tar', ['-xOf', tarballPath, 'package/lib/termux-run-claude-native.sh']);

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.187",
+  "version": "2.1.191",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "GPL-3.0-only",
   "bin": {


### PR DESCRIPTION
Automated upstream claude-code intake.

- upstream: @anthropic-ai/claude-code@2.1.191
- status: offset_discovered (Bun symbol offsets fixed)
- Bun fixes: typeof Bun 3→4, property access 34→36
- Opus 4.8 review: Go (2026-06-25)
- TUI verified: ✅ (2026-06-25)
- Next: npm candidate publish → Device B verification → promote to latest