### PR TITLE
fix: claude update が ~/.local prefix環境で更新されない (Issue #16)

### DIFF
--- a/packages/claude-code/lib/check-updates.js
+++ b/packages/claude-code/lib/check-updates.js
@@ -114,7 +114,8 @@ function shouldNotify(cache, latestVersion) {
 
 function installTarget(packageName, targetVersion) {
   const spec = `${packageName}@${targetVersion}`;
-  const command = `npm install -g ${spec}`;
+  const prefix = path.resolve(packageDir, '..', '..', '..', '..');
+  const command = `npm install -g --prefix ${prefix} ${spec}`;
 
   if (dryRun) {
     console.log(command);
@@ -122,7 +123,7 @@ function installTarget(packageName, targetVersion) {
   }
 
   console.error(`Updating to audited version ${targetVersion}`);
-  const result = cp.spawnSync('npm', ['install', '-g', spec], {
+  const result = cp.spawnSync('npm', ['install', '-g', '--prefix', prefix, spec], {
     stdio: 'inherit',
     env: process.env,
   });


### PR DESCRIPTION
## 概要
`claude update` を実行しても `~/.local` prefix環境（Termux標準セットアップ）で実際のバイナリが更新されない不具合を修正。

## 原因
`packages/claude-code/lib/check-updates.js` の `installTarget()` が `npm install -g <spec>` を `--prefix` なしで実行していたため、デフォルトprefix（$PREFIX）にインストールされ、PATH上の `~/.local/bin/claude` が更新されなかった。

## 修正
`installTarget()` で `packageDir` から prefix を動的導出し、`npm install -g --prefix <prefix> <spec>` を実行するよう変更。

## レビュー記録
- 設計レビュー: GPT-5.5 Go
- 実装: Claude Haiku 4.5
- diffレビュー: GPT-5.5 Go（パス計算・shell展開なし・最小パッチであることを確認）

## 関連
- bash0816/CluadeCode-Termux-private#16
- 2.1.198リリースに同梱

🤖 Generated with [Claude Code](https://claude.com/claude-code)