### PR TITLE
fix: Bun property access expectedCount 38->37 for 2.1.198

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -579,7 +579,7 @@ function rewriteNativeChunkSource(source) {
     /\bBun\./g,
     '__claudeBun.',
     'Bun property access',
-    38,
+    37,
   );
   patched = replaceRequired(
     patched,
@@ -1250,7 +1250,7 @@ function rewriteNativeChunkSource(source) {
     /\bBun\./g,
     '__claudeBun.',
     'Bun property access',
-    38,
+    37,
   );
   patched = replaceRequired(
     patched,

--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -279,7 +279,7 @@ test('cleanupStaleEntryFiles removes only stale extracted files for the same off
 
 function buildSyntheticBundleSource() {
   const typeofBun = Array.from({ length: 6 }, () => 'typeof Bun').join('; ');
-  const bunProps = Array.from({ length: 38 }, (_, index) => `Bun.p${index}`).join('; ');
+  const bunProps = Array.from({ length: 37 }, (_, index) => `Bun.p${index}`).join('; ');
   return `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0 }`;
 }
 
@@ -303,7 +303,7 @@ test('rewriteNativeChunkSource rejects unexpected replacement counts', () => {
 
   assert.throws(
     () => rewriteNativeChunkSource(source),
-    /unexpected Bun property access count 37/,
+    /unexpected Bun property access count 36/,
   );
 });
 


### PR DESCRIPTION
## 概要
2.1.198のnative binaryで`claude --version`実行時に以下のエラーで失敗する問題を修正:
```
Error: rewriteNativeChunkSource: unexpected Bun property access count 37
```

## 原因
upstream 2.1.198の minified bundle内で `Bun.` パターンの出現回数が37（2.1.197時点の期待値38から1減少）。過去にも毎バージョンで発生している既知のメンテナンスパターン（2.1.177で33、2.1.186で34、2.1.195で38、と順次更新済み、直近コミットb5c9bfc）。

## 検証
実際にキャッシュされた native binary からentry.jsを抽出し、rewriteNativeChunkSourceの実ロジックを順に適用して実測:
- 2.1.197: `Bun.` = 38 (現行コードの期待値と一致)
- 2.1.198: `Bun.` = 37 (不一致 → エラー)
他の置換パターン（typeof Bun等）は全て一致、変化なし。

## 修正
- `termux-run-claude-native.sh` の2箇所（重複定義）: `38` → `37`
- `termux-run-claude-native.test.js`: synthetic bundle count `38`→`37`、reject期待値 `37`→`36`

## レビュー記録
- 設計レビュー: GPT-5.5 Go（実測データ・過去パターンとの整合性を確認）
- 実装: Claude Haiku 4.5
- diffレビュー: GPT-5.5 Go（パス誤解による一時No-Goを訂正後、最終Go）
- `node --test`: 11 pass / 0 fail / 1 skipped(無関係)

## 関連
- 2.1.198リリースのDevice Aテスト中に発見（このPRがないとDevice Aテストが完了できない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)