### PR TITLE
fix: version-aware typeof Bun expectedCount for claude-code 2.1.200

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -553,12 +553,18 @@ function rewriteNativeChunkSource(source) {
     'module wrapper prefix',
     1,
   );
+  const _typeofBunExpected = (() => {
+    const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
+    const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 200)) return 7;
+    return 6;
+  })();
   patched = replaceRequired(
     patched,
     /\btypeof Bun\b/g,
     'typeof __claudeBun',
     'typeof Bun',
-    7,
+    _typeofBunExpected,
   );
   patched = replaceRequired(
     patched,
@@ -1224,12 +1230,18 @@ function rewriteNativeChunkSource(source) {
     'module wrapper prefix',
     1,
   );
+  const _typeofBunExpected = (() => {
+    const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
+    const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 200)) return 7;
+    return 6;
+  })();
   patched = replaceRequired(
     patched,
     /\btypeof Bun\b/g,
     'typeof __claudeBun',
     'typeof Bun',
-    7,
+    _typeofBunExpected,
   );
   patched = replaceRequired(
     patched,

--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -558,7 +558,7 @@ function rewriteNativeChunkSource(source) {
     /\btypeof Bun\b/g,
     'typeof __claudeBun',
     'typeof Bun',
-    6,
+    7,
   );
   patched = replaceRequired(
     patched,
@@ -1229,7 +1229,7 @@ function rewriteNativeChunkSource(source) {
     /\btypeof Bun\b/g,
     'typeof __claudeBun',
     'typeof Bun',
-    6,
+    7,
   );
   patched = replaceRequired(
     patched,

--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -78,7 +78,7 @@ function loadHelperApi() {
     '\n\nasync function main() {',
   );
 
-  const context = vm.createContext({ module: { exports: {} }, exports: {}, fs, path });
+  const context = vm.createContext({ module: { exports: {} }, exports: {}, fs, path, process });
   vm.runInContext(
     `${replaceSource}\n${cleanupSource}\n${fullWidthSource}\n${graphemeWidthSource}\n${stripAnsiSource}\n${stringWidthSource}\n${wrapAnsiSource}\n${stableHashSource}\n${rewriteSource}\nmodule.exports = { replaceRequired, cleanupStaleEntryFiles, isFullWidthCodePoint, graphemeWidth, stripANSI, stringWidth, wrapAnsi, stableHash, rewriteNativeChunkSource };`,
     context,
@@ -283,18 +283,44 @@ function buildSyntheticBundleSource() {
   return `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0 }`;
 }
 
-test('rewriteNativeChunkSource rewrites the synthetic bundle slice', () => {
-  const { rewriteNativeChunkSource } = loadHelperApi();
-  const source = buildSyntheticBundleSource();
-  const patched = rewriteNativeChunkSource(source);
+test('rewriteNativeChunkSource rewrites the synthetic bundle slice (version 2.1.198)', () => {
+  process.env.CURRENT_CLAUDE_VERSION = '2.1.198';
+  try {
+    const { rewriteNativeChunkSource } = loadHelperApi();
+    const source = buildSyntheticBundleSource();
+    const patched = rewriteNativeChunkSource(source);
 
-  assert.match(patched, /var __claudeBun = globalThis\.__claudeBunShim;/);
-  assert.match(patched, /typeof __claudeBun/);
-  assert.match(patched, /typeof globalThis\.__claudeBun/);
-  assert.match(patched, /globalThis\.__claudeBun/);
-  assert.match(patched, /__claudeBun\./);
-  assert.match(patched, /npmInstallDeprecated:!1/);
-  assert.doesNotMatch(patched, /npmInstallDeprecated:!0/);
+    assert.match(patched, /var __claudeBun = globalThis\.__claudeBunShim;/);
+    assert.match(patched, /typeof __claudeBun/);
+    assert.match(patched, /typeof globalThis\.__claudeBun/);
+    assert.match(patched, /globalThis\.__claudeBun/);
+    assert.match(patched, /__claudeBun\./);
+    assert.match(patched, /npmInstallDeprecated:!1/);
+    assert.doesNotMatch(patched, /npmInstallDeprecated:!0/);
+  } finally {
+    delete process.env.CURRENT_CLAUDE_VERSION;
+  }
+});
+
+test('rewriteNativeChunkSource rewrites the synthetic bundle slice (version 2.1.200)', () => {
+  process.env.CURRENT_CLAUDE_VERSION = '2.1.200';
+  try {
+    const { rewriteNativeChunkSource } = loadHelperApi();
+    const typeofBun = Array.from({ length: 7 }, () => 'typeof Bun').join('; ');
+    const bunProps = Array.from({ length: 37 }, (_, index) => `Bun.p${index}`).join('; ');
+    const source = `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0 }`;
+    const patched = rewriteNativeChunkSource(source);
+
+    assert.match(patched, /var __claudeBun = globalThis\.__claudeBunShim;/);
+    assert.match(patched, /typeof __claudeBun/);
+    assert.match(patched, /typeof globalThis\.__claudeBun/);
+    assert.match(patched, /globalThis\.__claudeBun/);
+    assert.match(patched, /__claudeBun\./);
+    assert.match(patched, /npmInstallDeprecated:!1/);
+    assert.doesNotMatch(patched, /npmInstallDeprecated:!0/);
+  } finally {
+    delete process.env.CURRENT_CLAUDE_VERSION;
+  }
 });
 
 test('rewriteNativeChunkSource rejects unexpected replacement counts', () => {


### PR DESCRIPTION
## Summary

- claude-code 2.1.200 upstream binary contains 7 occurrences of `typeof Bun` (previously 6)
- Fixed `termux-run-claude-native.sh` to select `expectedCount` dynamically based on `CURRENT_CLAUDE_VERSION` (≥2.1.200 → 7, otherwise → 6)
- Updated test fixture to cover both 2.1.198 (6 occurrences) and 2.1.200 (7 occurrences)

## Changes

- `packages/claude-code/lib/termux-run-claude-native.sh`: add `_typeofBunExpected` IIFE in both `rewriteNativeChunkSource` copies
- `packages/claude-code/lib/termux-run-claude-native.test.js`: split synthetic bundle test into version-specific cases; add `process` to vm context

## Review

GPT-5.5 reviewed: Go (no blockers)

## Test plan

- [ ] `node packages/claude-code/lib/termux-run-claude-native.test.js` → 12 pass
- [ ] Smoke test on Device A: `npm pack` → install → `claude --version`
- [ ] Device B full verification