### PR TITLE
fix: version-aware Bun property access expectedCount for 2.1.200

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -580,12 +580,18 @@ function rewriteNativeChunkSource(source) {
     'globalThis.Bun',
     1,
   );
+  const _bunPropertyAccessExpected = (() => {
+    const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
+    const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 200)) return 40;
+    return 37;
+  })();
   patched = replaceRequired(
     patched,
     /\bBun\./g,
     '__claudeBun.',
     'Bun property access',
-    37,
+    _bunPropertyAccessExpected,
   );
   patched = replaceRequired(
     patched,
@@ -1257,12 +1263,18 @@ function rewriteNativeChunkSource(source) {
     'globalThis.Bun',
     1,
   );
+  const _bunPropertyAccessExpected = (() => {
+    const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
+    const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 200)) return 40;
+    return 37;
+  })();
   patched = replaceRequired(
     patched,
     /\bBun\./g,
     '__claudeBun.',
     'Bun property access',
-    37,
+    _bunPropertyAccessExpected,
   );
   patched = replaceRequired(
     patched,

--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -307,7 +307,7 @@ test('rewriteNativeChunkSource rewrites the synthetic bundle slice (version 2.1.
   try {
     const { rewriteNativeChunkSource } = loadHelperApi();
     const typeofBun = Array.from({ length: 7 }, () => 'typeof Bun').join('; ');
-    const bunProps = Array.from({ length: 37 }, (_, index) => `Bun.p${index}`).join('; ');
+    const bunProps = Array.from({ length: 40 }, (_, index) => `Bun.p${index}`).join('; ');
     const source = `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0 }`;
     const patched = rewriteNativeChunkSource(source);
 


### PR DESCRIPTION
## Summary

Smoke test discovered that `Bun.property` access count increased from 37 to 40 in claude-code 2.1.200. Applies the same version-aware pattern as PR #186 (typeof Bun count).

- `CURRENT_CLAUDE_VERSION ≥ 2.1.200` → expectedCount 40
- `CURRENT_CLAUDE_VERSION < 2.1.200` → expectedCount 37 (unchanged)

## Changes

- `packages/claude-code/lib/termux-run-claude-native.sh`: add `_bunPropertyAccessExpected` IIFE in both `rewriteNativeChunkSource` copies
- `packages/claude-code/lib/termux-run-claude-native.test.js`: update 2.1.200 fixture to use 40 Bun props

## Review

GPT-5.5 reviewed: Go (no blockers)

## Test plan

- [x] `node packages/claude-code/lib/termux-run-claude-native.test.js` → 13 pass
- [x] Smoke test: `claude --version` → 2.1.200, no Bun errors
- [ ] Device B full verification