### PR TITLE
chore: mark 2.1.200 as termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -409,7 +409,7 @@
       "entry_end_offset": 246293109,
       "tarball_integrity": "sha512-FG0hXbPLzsmmtpbWwc1t1mbZ2HsrBNmn/QLkVMvYXAzxf4vXrHgM7AIZU1cCBNycufXwPAnyzOwO886kkBle7Q==",
       "tarball_sha256": "d7010d06bae10be2dca703633c730d52c5c1391165e8eccd49ff6e7c2571c244",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.198",
+  "latest_audited_version": "2.1.200",
   "latest_candidate_version": "2.1.200",
-  "previous_stable_version": "2.1.197",
+  "previous_stable_version": "2.1.198",
   "stable_pinned_version": "2.1.176",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Device B verification complete. Mark 2.1.200 termux_verified and update latest_audited_version.