### PR TITLE
fix: replace claude doctor with npm view; add retag_stable

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -49,6 +49,11 @@ on:
         required: false
         default: ""
         type: string
+      retag_stable:
+        description: "Retag @stable dist-tag to the specified version (must already be published)"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -131,7 +136,9 @@ jobs:
         run: npm pack --dry-run
 
   publish:
-    if: github.event_name == 'workflow_dispatch' && (inputs.publish == 'true' || inputs.retag_latest == 'true')
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      (inputs.publish == 'true' || inputs.retag_latest == 'true' || inputs.retag_stable != '')
     needs: verify
     runs-on: ubuntu-latest
     environment: npm-publish
@@ -156,8 +163,10 @@ jobs:
           node - <<'NODE'
           const publish = process.env.INPUT_PUBLISH === 'true';
           const retagLatest = process.env.INPUT_RETAG_LATEST === 'true';
-          if (publish && retagLatest) {
-            throw new Error('publish and retag_latest cannot both be true');
+          const retagStable = process.env.INPUT_RETAG_STABLE || '';
+          const modes = [publish, retagLatest, !!retagStable].filter(Boolean).length;
+          if (modes > 1) {
+            throw new Error('only one of publish / retag_latest / retag_stable can be specified at a time');
           }
           if (retagLatest && !process.env.INPUT_PREVIOUS_AUDITED_VERSION) {
             throw new Error('previous_audited_version is required when retag_latest is true');
@@ -166,6 +175,7 @@ jobs:
         env:
           INPUT_PUBLISH: ${{ inputs.publish }}
           INPUT_RETAG_LATEST: ${{ inputs.retag_latest }}
+          INPUT_RETAG_STABLE: ${{ inputs.retag_stable }}
           INPUT_PREVIOUS_AUDITED_VERSION: ${{ inputs.previous_audited_version }}
 
       - name: Publish guard
@@ -279,3 +289,19 @@ jobs:
           CLAUDE_TERMUX_EXPECTED_PREVIOUS_AUDITED_VERSION: ${{ inputs.previous_audited_version }}
         run: |
           node ../../scripts/retag-latest-dist-tags.js
+
+      - name: Retag stable
+        if: github.event_name == 'workflow_dispatch' && inputs.retag_stable != ''
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          target="${{ inputs.retag_stable }}"
+          existing=$(npm view "@bash0816/claude-code@${target}" version 2>/dev/null || echo "")
+          if [ -z "$existing" ]; then
+            echo "ERROR: @bash0816/claude-code@${target} is not published" >&2
+            exit 1
+          fi
+          echo "verified: @bash0816/claude-code@${target} exists"
+          npm dist-tag add "@bash0816/claude-code@${target}" stable
+          echo "Retagged @stable → ${target}"

--- a/scripts/update-readme-from-doctor.js
+++ b/scripts/update-readme-from-doctor.js
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-// Runs `claude doctor` and updates README.md with upstream version info.
-// Call this at release time after installing the new package version.
-
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
 const manifestFile = path.join(repoRoot, 'config', 'claude-termux-release-manifest.json');
@@ -15,77 +13,28 @@ const packageReadmeFile = path.join(repoRoot, 'packages', 'claude-code', 'README
 const START = '<!-- UPSTREAM_VERSION_START -->';
 const END = '<!-- UPSTREAM_VERSION_END -->';
 
-function stripAnsi(text) {
-  return text
-    .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
-    .replace(/\x1b[=>]/g, '')
-    .replace(/\x1b\[[0-9]+[GH]/g, ' ')
-    .replace(/[^\x20-\x7e\n]/g, '');
-}
-
-function runDoctor() {
-  return new Promise((resolve, reject) => {
-    const { spawn } = require('child_process');
-    // script(1) allocates a PTY so claude doctor renders version info
-    const proc = spawn('script', ['-q', '-c', 'claude doctor', '/dev/null'], {
-      env: { ...process.env },
-      detached: true,
-    });
-    let output = '';
-    proc.stdout.on('data', d => { output += d.toString(); });
-    proc.stderr.on('data', d => { output += d.toString(); });
-
-    // Auto-close: send Enter after 8s to dismiss the TUI, then kill at 15s
-    const enterTimer = setTimeout(() => {
-      try { proc.stdin.write('\n'); } catch (_) {}
-    }, 8000);
-    let timedOut = false;
-    const killTimer = setTimeout(() => {
-      timedOut = true;
-      try { process.kill(-proc.pid, 'SIGKILL'); } catch (_) {}
-    }, 15000);
-
-    proc.on('close', (code, signal) => {
-      clearTimeout(enterTimer);
-      clearTimeout(killTimer);
-      resolve({ output: stripAnsi(output), timedOut, exitCode: code });
-    });
-    proc.on('error', err => {
-      clearTimeout(enterTimer);
-      clearTimeout(killTimer);
-      reject(err);
-    });
-  });
-}
-
-function parseDoctor(output) {
-  // Normalize: cursor-position codes merge lines; search the whole blob
-  const blob = output.replace(/\s+/g, ' ');
-  let latestVersion = null;
-  let stableVersion = null;
-
-  const latestMatch = blob.match(/[Ll]atest\s*version\s*:\s*(\d[\d.]+(?:-[\w.]+)?)/);
-  if (latestMatch) latestVersion = latestMatch[1];
-
-  const stableMatch = blob.match(/[Ss]table\s*version\s*:\s*(\d[\d.]+(?:-[\w.]+)?)/);
-  if (stableMatch) stableVersion = stableMatch[1];
-
-  return { latestVersion, stableVersion };
+function fetchUpstreamDistTags() {
+  try {
+    const raw = execSync('npm view @anthropic-ai/claude-code dist-tags --json', { encoding: 'utf8' });
+    const tags = JSON.parse(raw);
+    return { latestVersion: tags.latest || null, stableVersion: tags.stable || null };
+  } catch (err) {
+    console.error(`WARNING: failed to fetch upstream dist-tags: ${err.message}`);
+    return { latestVersion: null, stableVersion: null };
+  }
 }
 
 function replaceBetween(content, startAnchor, endAnchor, replacement, fileLabel) {
   const startIndex = content.indexOf(startAnchor);
   if (startIndex === -1) throw new Error(`start anchor not found in ${fileLabel}`);
-  const searchIndex = startIndex + startAnchor.length;
-  const endIndex = content.indexOf(endAnchor, searchIndex);
+  const endIndex = content.indexOf(endAnchor, startIndex + startAnchor.length);
   if (endIndex === -1) throw new Error(`end anchor not found in ${fileLabel}`);
   return content.slice(0, startIndex) + startAnchor + replacement + endAnchor + content.slice(endIndex + endAnchor.length);
 }
 
 function buildSection(upstream, ourVersion) {
-  const { latestVersion, stableVersion } = upstream;
-  const upstreamLatest = latestVersion || '(unknown)';
-  const upstreamStable = stableVersion || '(unknown)';
+  const upstreamLatest = upstream.latestVersion || '(unknown)';
+  const upstreamStable = upstream.stableVersion || '(unknown)';
   return `
 Official upstream (\`@anthropic-ai/claude-code\`): latest \`${upstreamLatest}\` / stable \`${upstreamStable}\`
 This repo's published latest audited release: \`${ourVersion}\`
@@ -106,44 +55,28 @@ function updateReadme(filePath, section) {
   console.log(`updated: ${path.relative(repoRoot, filePath)}`);
 }
 
-async function main() {
+function main() {
   const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
   const ourVersion = manifest.latest_audited_version;
   if (!ourVersion) throw new Error('latest_audited_version not set in manifest');
 
-  console.log('running claude doctor...');
-  const doctorOutput = await runDoctor();
-
-  if (doctorOutput.timedOut) {
-    console.error('ERROR: claude doctor timed out');
-    process.exit(1);
-  }
-  if (doctorOutput.exitCode !== 0 && doctorOutput.exitCode !== null) {
-    console.error(`ERROR: claude doctor exited with code ${doctorOutput.exitCode}`);
-    process.exit(1);
-  }
-
-  const upstream = parseDoctor(doctorOutput.output);
+  console.log('fetching upstream dist-tags...');
+  const upstream = fetchUpstreamDistTags();
   console.log(`upstream latest: ${upstream.latestVersion || '(not found)'}`);
   console.log(`upstream stable: ${upstream.stableVersion || '(not found)'}`);
   console.log(`our version:     ${ourVersion}`);
 
   if (!upstream.latestVersion || !upstream.stableVersion) {
     const missing = [!upstream.latestVersion && 'latestVersion', !upstream.stableVersion && 'stableVersion'].filter(Boolean).join(', ');
-    console.error(`WARNING: could not parse from claude doctor output: ${missing}`);
+    console.error(`WARNING: could not fetch from upstream: ${missing}`);
     if (process.argv.includes('--strict')) process.exit(1);
-    console.error('skipping README update to avoid writing (unknown)');
+    console.error('skipping README update');
     process.exit(0);
   }
 
   const section = buildSection(upstream, ourVersion);
   updateReadme(rootReadmeFile, section);
-  if (fs.existsSync(packageReadmeFile)) {
-    updateReadme(packageReadmeFile, section);
-  }
+  if (fs.existsSync(packageReadmeFile)) updateReadme(packageReadmeFile, section);
 }
 
-main().catch(err => {
-  console.error(err.message || err);
-  process.exit(1);
-});
+main();


### PR DESCRIPTION
## Summary
- `update-readme-from-doctor.js`: `claude doctor` TUI パースを廃止し `npm view @anthropic-ai/claude-code dist-tags --json` で upstream バージョンを直接取得するよう修正
- `npm-package.yml`: `retag_stable` input を追加し、`@stable` dist-tag を指定バージョンに更新できる仕組みを追加（事前に指定バージョンが publish 済みであることをガードで確認）

## 変更ファイル
- `scripts/update-readme-from-doctor.js`
- `.github/workflows/npm-package.yml`