### PR TITLE
fix: retag-stable script injection + update stable_pinned_version to 2.1.193

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -294,9 +294,10 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.retag_stable != ''
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          INPUT_RETAG_STABLE: ${{ inputs.retag_stable }}
         run: |
           set -euo pipefail
-          target="${{ inputs.retag_stable }}"
+          target="${INPUT_RETAG_STABLE}"
           existing=$(npm view "@bash0816/claude-code@${target}" version 2>/dev/null || echo "")
           if [ -z "$existing" ]; then
             echo "ERROR: @bash0816/claude-code@${target} is not published" >&2

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Only versions registered in the audited metadata can run.
 |---------|--------|
 | `2.1.201` | ✅ **Recommended / 推奨** — latest |
 | `2.1.200` | ✅ rollback candidate — `@candidate` dist-tag |
-| `2.1.176` | ✅ stable — `@stable` dist-tag |
+| `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
 <!-- UPSTREAM_VERSION_START -->

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -4,6 +4,6 @@
   "latest_audited_version": "2.1.201",
   "latest_candidate_version": "2.1.201",
   "previous_stable_version": "2.1.200",
-  "stable_pinned_version": "2.1.176",
+  "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -4,6 +4,6 @@
   "latest_audited_version": "2.1.201",
   "latest_candidate_version": "2.1.201",
   "previous_stable_version": "2.1.200",
-  "stable_pinned_version": "2.1.176",
+  "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Changes
- Fix script injection in `Retag stable` step: pass `inputs.retag_stable` via env var instead of direct `${{ }}` expansion in shell (same pattern as PR #12 fix for release-finalize.yml)
- Update `stable_pinned_version` from `2.1.176` to `2.1.193` in both manifests (npm @stable dist-tag was already updated to 2.1.193 by workflow_dispatch; this syncs the repo config)
- Update README supported versions table via update-readme-version-guidance.js

## Rollback
- Pre-merge: close PR
- Post-merge, pre-dispatch: `git revert` + PR to main  
- If @stable dist-tag is accidentally changed: `npm dist-tag add "@bash0816/claude-code@2.1.193" stable` to restore