### PR TITLE
release: promote 2.1.207 to termux_verified, update manifest and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.206-1
+npm install -g @bash0816/claude-code@2.1.207
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.206-1` | ✅ **Recommended / 推奨** — latest |
-| `2.1.206` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.207` | ✅ **Recommended / 推奨** — latest |
+| `2.1.206-1` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.206-1 (Claude Code)
+2.1.207 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -481,7 +481,7 @@
       "entry_end_offset": 250874310,
       "tarball_integrity": "sha512-Jmcvn8Sg8+FaPLOy9t4h7ip+K1i5YYrimT1+iZL1YHBTA44WHJ9H/F8DW3QKnVyqUGqEza9Tg5PPVjzhi5fwyg==",
       "tarball_sha256": "02c381be3269489119287dc0b5f4b99b870d886f058918994b51e06b701dd1be",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.206-1",
+  "latest_audited_version": "2.1.207",
   "latest_candidate_version": "2.1.207",
-  "previous_stable_version": "2.1.206",
+  "previous_stable_version": "2.1.206-1",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.206-1
+npm install -g @bash0816/claude-code@2.1.207
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -481,7 +481,7 @@
       "entry_end_offset": 250874310,
       "tarball_integrity": "sha512-Jmcvn8Sg8+FaPLOy9t4h7ip+K1i5YYrimT1+iZL1YHBTA44WHJ9H/F8DW3QKnVyqUGqEza9Tg5PPVjzhi5fwyg==",
       "tarball_sha256": "02c381be3269489119287dc0b5f4b99b870d886f058918994b51e06b701dd1be",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.206-1",
+  "latest_audited_version": "2.1.207",
   "latest_candidate_version": "2.1.207",
-  "previous_stable_version": "2.1.206",
+  "previous_stable_version": "2.1.206-1",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
Promote claude-code 2.1.207 to termux_verified status and update release manifests.

- Update `status` in audited-versions configs to `termux_verified`
- Update manifest `latest_audited_version` to 2.1.207
- Update README version guidance and supported versions table

## Test plan
- ✅ Static validation: all 6 expected files changed, no unexpected diffs
- ✅ Manifest consistency verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)