### PR TITLE
release: promote 2.1.209 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -490,7 +490,7 @@
       "entry_end_offset": 251454713,
       "tarball_integrity": "sha512-l2DaZkuwJegv+nzd6NiaU2qF/jU/IePbry0LthAiC7jV9KtMF0O7BCem6qxGhsrr99GGeEk0XbfUN6qJTacrHg==",
       "tarball_sha256": "3026124b1ccb1af11fc556173e105e2d2d534459b359caaa33dcf1809573d4b2",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.207",
+  "latest_audited_version": "2.1.209",
   "latest_candidate_version": "2.1.209",
-  "previous_stable_version": "2.1.206-1",
+  "previous_stable_version": "2.1.207",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -490,7 +490,7 @@
       "entry_end_offset": 251454713,
       "tarball_integrity": "sha512-l2DaZkuwJegv+nzd6NiaU2qF/jU/IePbry0LthAiC7jV9KtMF0O7BCem6qxGhsrr99GGeEk0XbfUN6qJTacrHg==",
       "tarball_sha256": "3026124b1ccb1af11fc556173e105e2d2d534459b359caaa33dcf1809573d4b2",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.207",
+  "latest_audited_version": "2.1.209",
   "latest_candidate_version": "2.1.209",
-  "previous_stable_version": "2.1.206-1",
+  "previous_stable_version": "2.1.207",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote claude-code 2.1.209 to termux_verified status following the 2.1.207 precedent (commit 2f9ca3a). Device B install/auth/update/rollback verification confirmed OK by user.