### PR TITLE
release: promote 2.1.210 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -499,7 +499,7 @@
       "entry_end_offset": 252585603,
       "tarball_integrity": "sha512-eU6EVzxfey1ceW3qx7zrwWpoh6RnqUbLAFKK//IAqe2RWS3YkO8ABh7rgdWcGUADLAQ5YjTnGrX6VnFufJbZdw==",
       "tarball_sha256": "cd2ecbb955973cdb5f2fe5666ea4a0e6bdb3b038aa16c82b0786cb4da03ac5ec",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.209",
+  "latest_audited_version": "2.1.210",
   "latest_candidate_version": "2.1.210",
-  "previous_stable_version": "2.1.207",
+  "previous_stable_version": "2.1.209",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -499,7 +499,7 @@
       "entry_end_offset": 252585603,
       "tarball_integrity": "sha512-eU6EVzxfey1ceW3qx7zrwWpoh6RnqUbLAFKK//IAqe2RWS3YkO8ABh7rgdWcGUADLAQ5YjTnGrX6VnFufJbZdw==",
       "tarball_sha256": "cd2ecbb955973cdb5f2fe5666ea4a0e6bdb3b038aa16c82b0786cb4da03ac5ec",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.209",
+  "latest_audited_version": "2.1.210",
   "latest_candidate_version": "2.1.210",
-  "previous_stable_version": "2.1.207",
+  "previous_stable_version": "2.1.209",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote claude-code 2.1.210 to termux_verified status following the 2.1.209 precedent (commit 7a6936b). Device A (this machine) TUI verification and Device B install/auth/update/rollback verification confirmed OK by user.