### PR TITLE
Promote claude-code 2.1.211 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -508,7 +508,7 @@
       "entry_end_offset": 253525517,
       "tarball_integrity": "sha512-ZPthYxltbqA87X/avbAHA0XVPuFuqoNrXKRmx0G0qfwEuyyloVKdaUsY1AEbFXQIRJYKZZ8UvMklD2jvm9+etA==",
       "tarball_sha256": "4dbc55a90cae5f6e3946267c61b1b6491e09abbb1a3005669e0ffd128d2624f6",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.210",
+  "latest_audited_version": "2.1.211",
   "latest_candidate_version": "2.1.211",
-  "previous_stable_version": "2.1.209",
+  "previous_stable_version": "2.1.210",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -508,7 +508,7 @@
       "entry_end_offset": 253525517,
       "tarball_integrity": "sha512-ZPthYxltbqA87X/avbAHA0XVPuFuqoNrXKRmx0G0qfwEuyyloVKdaUsY1AEbFXQIRJYKZZ8UvMklD2jvm9+etA==",
       "tarball_sha256": "4dbc55a90cae5f6e3946267c61b1b6491e09abbb1a3005669e0ffd128d2624f6",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.210",
+  "latest_audited_version": "2.1.211",
   "latest_candidate_version": "2.1.211",
-  "previous_stable_version": "2.1.209",
+  "previous_stable_version": "2.1.210",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote 2.1.211 from candidate to termux_verified status after successful TUI/functional verification on Device A and Device B.

- Updated status in config/claude-native-audited-versions.json
- Updated latest_audited_version in release manifest
- Updated previous_stable_version accordingly