### PR TITLE
fix: printf化でrelease-finalize.ymlのheredoc YAML構文破壊リスクを解消

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -122,19 +122,14 @@ jobs:
           if grep -qF "## ${VER} " RELEASES.md; then
             echo "RELEASES.md already has ${VER} entry, skipping"
           else
-            entry=$(cat <<RELNOTES_EOF_9f3a2b
-          ## ${VER} — ${date_str} ✅ Current audited / 現在の監査済み版
-
-          ${notes}
-
-          \`\`\`sh
-          npm install -g @bash0816/claude-code@latest
-          \`\`\`
-          ${rollback_line}
-
-          ---
-
-          RELNOTES_EOF_9f3a2b
+            entry=$(
+            printf '## %s — %s ✅ Current audited / 現在の監査済み版\n\n' "$VER" "$date_str"
+            printf '%s\n\n' "$notes"
+            printf '```sh\n'
+            printf 'npm install -g @bash0816/claude-code@latest\n'
+            printf '```\n'
+            printf '%s\n\n' "$rollback_line"
+            printf -- '---\n\n'
           )
             printf '%s\n' "$entry" > /tmp/new_entry.md
             cat /tmp/new_entry.md RELEASES.md > /tmp/releases_new.md


### PR DESCRIPTION
以前のコミットd0c338aでheredocの中身を10スペースインデントしてYAML構文エラーを回避していたが、この方式は姉妹リポジトリ(Codex-Termux・Github-Copilot-Termux)で実際にYAML構文エラーを起こしており脆弱だった。heredocを廃止しprintfの複数回呼び出しに置換することで、根本的にこのリスクを解消する。G1/G2(10回)/G3レビュー全てGo確定。