### PR TITLE
fix: suppress shellcheck SC2016 false positive in release-finalize.yml

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -116,6 +116,7 @@ jobs:
           fi
           rollback_line=""
           if [ -n "$previous_stable" ]; then
+            # shellcheck disable=SC2016  # markdown code fence backticks are misread as command substitution, not a real expansion issue
             rollback_line=$(printf '\n```sh\nnpm install -g @bash0816/claude-code@%s\n```' "$previous_stable")
           fi
           # Use ## VER (with trailing space) to avoid partial match (e.g. 2.1.177 matching 2.1.177-1)


### PR DESCRIPTION
## 概要

mainブランチの Lint ワークフロー（actionlint/shellcheck）が、release-finalize.yml 119行目の Markdown コードフェンス（バッククォート3連）を shellcheck が誤ってコマンド置換（SC2016）と認識していました。

## 修正内容

- 119行目の直前に shellcheck 指令コメントを追加
- `# shellcheck disable=SC2016  # markdown code fence backticks are misread as command substitution, not a real expansion issue`
- **実行ロジックは無変更** — printfの出力内容（生成されるrollbackコマンド文字列）は一切変更なし

## CI 確認待ち

Lint/actionlint が正常にpassすることを確認予定。

## レビュー状況

本修正は GPT-5.6-terra による G1/G2 設計・実装プランレビュー で既に Go 判定を得ています。