### PR TITLE
Promote claude-code 2.1.212 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.211
+npm install -g @bash0816/claude-code@2.1.212
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.211` | ✅ **Recommended / 推奨** — latest |
-| `2.1.210` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.212` | ✅ **Recommended / 推奨** — latest |
+| `2.1.211` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.211 (Claude Code)
+2.1.212 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Only versions registered in the audited metadata can run.
 **日本語:** バージョン 2.1.206-1 (候補版) では、Termux 版の `/model` コマンドで Fable 5 モデル選択肢が表示されない不具合を修正しました。原因は起動時に `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` が強制 export されており、upstream の Bootstrap 処理（モデル取得）が抑制されていました。
 
 <!-- UPSTREAM_VERSION_START -->
-Official upstream (`@anthropic-ai/claude-code`): latest `2.1.201` / stable `2.1.193`
-This repo's published latest audited release: `2.1.201`
+Official upstream (`@anthropic-ai/claude-code`): latest `2.1.212` / stable `2.1.205`
+This repo's published latest audited release: `2.1.212`
 
-公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.201` / stable `2.1.193`
-この repo の公開 latest audited release: `2.1.201`
+公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.212` / stable `2.1.205`
+この repo の公開 latest audited release: `2.1.212`
 <!-- UPSTREAM_VERSION_END -->
 
 For the full version history, see [RELEASES.md](RELEASES.md).

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Only versions registered in the audited metadata can run.
 **日本語:** バージョン 2.1.206-1 (候補版) では、Termux 版の `/model` コマンドで Fable 5 モデル選択肢が表示されない不具合を修正しました。原因は起動時に `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` が強制 export されており、upstream の Bootstrap 処理（モデル取得）が抑制されていました。
 
 <!-- UPSTREAM_VERSION_START -->
-Official upstream (`@anthropic-ai/claude-code`): latest `2.1.212` / stable `2.1.205`
+Official upstream (`@anthropic-ai/claude-code`): latest `2.1.214` / stable `2.1.205`
 This repo's published latest audited release: `2.1.212`
 
-公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.212` / stable `2.1.205`
+公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.214` / stable `2.1.205`
 この repo の公開 latest audited release: `2.1.212`
 <!-- UPSTREAM_VERSION_END -->
 

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -517,7 +517,7 @@
       "entry_end_offset": 254615605,
       "tarball_integrity": "sha512-PcQptwO1t9q6tkL41yjmf5jxLU7Kzce4apW6KzuDvffN8ueKzGfR+9PecyQt2W1/dD2x1fAhWjAaQA6XiP2SyQ==",
       "tarball_sha256": "4aa1adabed3fe20a193c87450e25f82b04de65d97cea75fa5a0e80a0e910dbf8",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.211",
+  "latest_audited_version": "2.1.212",
   "latest_candidate_version": "2.1.212",
-  "previous_stable_version": "2.1.210",
+  "previous_stable_version": "2.1.211",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.211
+npm install -g @bash0816/claude-code@2.1.212
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -517,7 +517,7 @@
       "entry_end_offset": 254615605,
       "tarball_integrity": "sha512-PcQptwO1t9q6tkL41yjmf5jxLU7Kzce4apW6KzuDvffN8ueKzGfR+9PecyQt2W1/dD2x1fAhWjAaQA6XiP2SyQ==",
       "tarball_sha256": "4aa1adabed3fe20a193c87450e25f82b04de65d97cea75fa5a0e80a0e910dbf8",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.211",
+  "latest_audited_version": "2.1.212",
   "latest_candidate_version": "2.1.212",
-  "previous_stable_version": "2.1.210",
+  "previous_stable_version": "2.1.211",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote 2.1.212 from candidate to termux_verified status after successful TUI/functional verification on Device A and Device B.

- Updated status in config/claude-native-audited-versions.json
- Updated latest_audited_version in release manifest
- Updated previous_stable_version accordingly