### PR TITLE
fix: add Bun property access threshold for claude-code 2.1.214

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -583,6 +583,7 @@ function rewriteNativeChunkSource(source) {
   const _bunPropertyAccessExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 214)) return 39;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 205)) return 38;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 202)) return 41;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 200)) return 40;
@@ -1273,6 +1274,7 @@ function rewriteNativeChunkSource(source) {
   const _bunPropertyAccessExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 214)) return 39;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 205)) return 38;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 202)) return 41;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 200)) return 40;

--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -403,6 +403,44 @@ test('rewriteNativeChunkSource rejects stale Bun property access count for versi
   }
 });
 
+test('rewriteNativeChunkSource rewrites the synthetic bundle slice (version 2.1.214)', () => {
+  process.env.CURRENT_CLAUDE_VERSION = '2.1.214';
+  try {
+    const { rewriteNativeChunkSource } = loadHelperApi();
+    const typeofBun = Array.from({ length: 7 }, () => 'typeof Bun').join('; ');
+    const bunProps = Array.from({ length: 39 }, (_, index) => `Bun.p${index}`).join('; ');
+    const source = `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0; npmInstallDeprecated:!0 }`;
+    const patched = rewriteNativeChunkSource(source);
+
+    assert.match(patched, /var __claudeBun = globalThis\.__claudeBunShim;/);
+    assert.match(patched, /typeof __claudeBun/);
+    assert.match(patched, /typeof globalThis\.__claudeBun/);
+    assert.match(patched, /globalThis\.__claudeBun/);
+    assert.match(patched, /__claudeBun\./);
+    assert.match(patched, /npmInstallDeprecated:!1/);
+    assert.doesNotMatch(patched, /npmInstallDeprecated:!0/);
+  } finally {
+    delete process.env.CURRENT_CLAUDE_VERSION;
+  }
+});
+
+test('rewriteNativeChunkSource rejects stale Bun property access count for version 2.1.214', () => {
+  process.env.CURRENT_CLAUDE_VERSION = '2.1.214';
+  try {
+    const { rewriteNativeChunkSource } = loadHelperApi();
+    const typeofBun = Array.from({ length: 7 }, () => 'typeof Bun').join('; ');
+    const bunProps = Array.from({ length: 38 }, (_, index) => `Bun.p${index}`).join('; ');
+    const source = `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0; npmInstallDeprecated:!0 }`;
+
+    assert.throws(
+      () => rewriteNativeChunkSource(source),
+      /unexpected Bun property access count 38/,
+    );
+  } finally {
+    delete process.env.CURRENT_CLAUDE_VERSION;
+  }
+});
+
 test('rewriteNativeChunkSource rejects unexpected replacement counts', () => {
   const { rewriteNativeChunkSource } = loadHelperApi();
   const source = buildSyntheticBundleSource().replace('Bun.p30;', '');


### PR DESCRIPTION
G1レビュー(GPT-5.6-terra、実チャンク解析で確定、2往復)で確定した修正。実機起動失敗(unexpected Bun property access count 39)への対応、`>=214 => 39`の新閾値分岐を`_helper`/`_bootstrap`両方に追加。回帰テスト2件追加、実機で--version/-p/doctor全て確認済み。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>