### PR TITLE
Promote claude-code 2.1.214 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.212
+npm install -g @bash0816/claude-code@2.1.214
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.212` | ✅ **Recommended / 推奨** — latest |
-| `2.1.211` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.214` | ✅ **Recommended / 推奨** — latest |
+| `2.1.212` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -97,10 +97,10 @@ Only versions registered in the audited metadata can run.
 
 <!-- UPSTREAM_VERSION_START -->
 Official upstream (`@anthropic-ai/claude-code`): latest `2.1.214` / stable `2.1.205`
-This repo's published latest audited release: `2.1.212`
+This repo's published latest audited release: `2.1.214`
 
 公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.214` / stable `2.1.205`
-この repo の公開 latest audited release: `2.1.212`
+この repo の公開 latest audited release: `2.1.214`
 <!-- UPSTREAM_VERSION_END -->
 
 For the full version history, see [RELEASES.md](RELEASES.md).
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.212 (Claude Code)
+2.1.214 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -526,7 +526,7 @@
       "entry_end_offset": 255659218,
       "tarball_integrity": "sha512-WqNC8frNnFfNU6pFUilEk6bRWFjVI//iyZzB4VT4k9jRVJCsF4j2mrpu3AcDHbtVUqiBYsjfGXGjHmXtdhzZNw==",
       "tarball_sha256": "64f555b005d4ffa3998482152e8a359b5d7f0b0df56f2246173cc495e6cc2f0b",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.212",
+  "latest_audited_version": "2.1.214",
   "latest_candidate_version": "2.1.214",
-  "previous_stable_version": "2.1.211",
+  "previous_stable_version": "2.1.212",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.212
+npm install -g @bash0816/claude-code@2.1.214
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -526,7 +526,7 @@
       "entry_end_offset": 255659218,
       "tarball_integrity": "sha512-WqNC8frNnFfNU6pFUilEk6bRWFjVI//iyZzB4VT4k9jRVJCsF4j2mrpu3AcDHbtVUqiBYsjfGXGjHmXtdhzZNw==",
       "tarball_sha256": "64f555b005d4ffa3998482152e8a359b5d7f0b0df56f2246173cc495e6cc2f0b",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.212",
+  "latest_audited_version": "2.1.214",
   "latest_candidate_version": "2.1.214",
-  "previous_stable_version": "2.1.211",
+  "previous_stable_version": "2.1.212",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote 2.1.214 from candidate to termux_verified status after
successful TUI/functional verification on Device A and Device B.
Updates latest_audited_version from 2.1.212 to 2.1.214 and
previous_stable_version from 2.1.211 to 2.1.212.