### PR TITLE
Promote claude-code 2.1.215 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.214
+npm install -g @bash0816/claude-code@2.1.215
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.214` | ✅ **Recommended / 推奨** — latest |
-| `2.1.212` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.215` | ✅ **Recommended / 推奨** — latest |
+| `2.1.214` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -96,11 +96,11 @@ Only versions registered in the audited metadata can run.
 **日本語:** バージョン 2.1.206-1 (候補版) では、Termux 版の `/model` コマンドで Fable 5 モデル選択肢が表示されない不具合を修正しました。原因は起動時に `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` が強制 export されており、upstream の Bootstrap 処理（モデル取得）が抑制されていました。
 
 <!-- UPSTREAM_VERSION_START -->
-Official upstream (`@anthropic-ai/claude-code`): latest `2.1.214` / stable `2.1.205`
-This repo's published latest audited release: `2.1.214`
+Official upstream (`@anthropic-ai/claude-code`): latest `2.1.215` / stable `2.1.205`
+This repo's published latest audited release: `2.1.215`
 
-公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.214` / stable `2.1.205`
-この repo の公開 latest audited release: `2.1.214`
+公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.215` / stable `2.1.205`
+この repo の公開 latest audited release: `2.1.215`
 <!-- UPSTREAM_VERSION_END -->
 
 For the full version history, see [RELEASES.md](RELEASES.md).
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.214 (Claude Code)
+2.1.215 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -535,7 +535,7 @@
       "entry_end_offset": 255687124,
       "tarball_integrity": "sha512-wyfnBQBkZpYKXQ2+SGqtJRqzGfm06zN94JoetsqJa8CYvCZvkzApfBRgqzsLALGBtLK7Xf13HdED+SPd1R3T9w==",
       "tarball_sha256": "0c8b5a54f30b08c4a1fbc3f88679c15d0ba10af0e7516862abaf4cb1414fb7ab",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.214",
+  "latest_audited_version": "2.1.215",
   "latest_candidate_version": "2.1.215",
-  "previous_stable_version": "2.1.212",
+  "previous_stable_version": "2.1.214",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.214
+npm install -g @bash0816/claude-code@2.1.215
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -535,7 +535,7 @@
       "entry_end_offset": 255687124,
       "tarball_integrity": "sha512-wyfnBQBkZpYKXQ2+SGqtJRqzGfm06zN94JoetsqJa8CYvCZvkzApfBRgqzsLALGBtLK7Xf13HdED+SPd1R3T9w==",
       "tarball_sha256": "0c8b5a54f30b08c4a1fbc3f88679c15d0ba10af0e7516862abaf4cb1414fb7ab",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.214",
+  "latest_audited_version": "2.1.215",
   "latest_candidate_version": "2.1.215",
-  "previous_stable_version": "2.1.212",
+  "previous_stable_version": "2.1.214",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary

Promote 2.1.215 from candidate to termux_verified status after successful TUI/functional verification on Device A and Device B.

Updates latest_audited_version from 2.1.214 to 2.1.215 and previous_stable_version from 2.1.212 to 2.1.214.

## Changes

- **config/claude-native-audited-versions.json**: Updated 2.1.215 status from `offset_discovered` to `termux_verified`
- **config/claude-termux-release-manifest.json**: Updated `latest_audited_version` to 2.1.215 and `previous_stable_version` to 2.1.214
- **README.md**: Updated version references and version table (4 changes)
- **packages/claude-code/** config files: Same changes as root config files

🤖 Generated with Claude Code