### PR TITLE
fix: add Bun property access threshold for claude-code 2.1.216

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -583,6 +583,7 @@ function rewriteNativeChunkSource(source) {
   const _bunPropertyAccessExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 216)) return 40;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 214)) return 39;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 205)) return 38;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 202)) return 41;
@@ -1274,6 +1275,7 @@ function rewriteNativeChunkSource(source) {
   const _bunPropertyAccessExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 216)) return 40;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 214)) return 39;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 205)) return 38;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 202)) return 41;

--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -441,6 +441,43 @@ test('rewriteNativeChunkSource rejects stale Bun property access count for versi
   }
 });
 
+test('rewriteNativeChunkSource rewrites the synthetic bundle slice (version 2.1.216)', () => {
+  process.env.CURRENT_CLAUDE_VERSION = '2.1.216';
+  try {
+    const { rewriteNativeChunkSource } = loadHelperApi();
+    const typeofBun = Array.from({ length: 7 }, () => 'typeof Bun').join('; ');
+    const bunProps = Array.from({ length: 40 }, (_, index) => `Bun.p${index}`).join('; ');
+    const source = `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0; npmInstallDeprecated:!0 }`;
+    const patched = rewriteNativeChunkSource(source);
+
+    assert.match(patched, /var __claudeBun = globalThis\.__claudeBunShim;/);
+    assert.match(patched, /typeof __claudeBun/);
+    assert.match(patched, /typeof globalThis\.__claudeBun/);
+    assert.match(patched, /globalThis\.__claudeBun/);
+    assert.match(patched, /__claudeBun\./);
+    assert.equal((patched.match(/__claudeBun\./g) || []).length, 40);
+  } finally {
+    delete process.env.CURRENT_CLAUDE_VERSION;
+  }
+});
+
+test('rewriteNativeChunkSource rejects stale Bun property access count for version 2.1.216', () => {
+  process.env.CURRENT_CLAUDE_VERSION = '2.1.216';
+  try {
+    const { rewriteNativeChunkSource } = loadHelperApi();
+    const typeofBun = Array.from({ length: 7 }, () => 'typeof Bun').join('; ');
+    const bunProps = Array.from({ length: 39 }, (_, index) => `Bun.p${index}`).join('; ');
+    const source = `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0; npmInstallDeprecated:!0 }`;
+
+    assert.throws(
+      () => rewriteNativeChunkSource(source),
+      /unexpected Bun property access count 39/,
+    );
+  } finally {
+    delete process.env.CURRENT_CLAUDE_VERSION;
+  }
+});
+
 test('rewriteNativeChunkSource rejects unexpected replacement counts', () => {
   const { rewriteNativeChunkSource } = loadHelperApi();
   const source = buildSyntheticBundleSource().replace('Bun.p30;', '');


### PR DESCRIPTION
## Summary
- claude-code 2.1.216 の実バンドルで `Bun.` プロパティアクセス出現数が40件(前回2.1.214時点の閾値39から+1)に増加し、`rewriteNativeChunkSource`の`replaceRequired`が例外を投げ起動不能だった
- `_bunPropertyAccessExpected`（`_helper`用583行目・`_bootstrap`用1273行目の2箇所、同一ロジック重複）に`>=216`→40の新分岐を追加
- 2.1.214追加時と同型の回帰テスト2件（正常系・stale値での例外発生確認）を追加

## Test plan
- [x] `node --test lib/termux-run-claude-native.test.js` → 22/22 PASS
- [x] `npm pack` → tgz生成 → グローバルインストール
- [x] `claude --version` → `2.1.216 (Claude Code)`
- [x] `claude -p "1+1は何ですか？一言で答えてください"` → `2`（exit 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)