### PR TITLE
chore: promote claude-code 2.1.216 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.215
+npm install -g @bash0816/claude-code@2.1.216
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.215` | ✅ **Recommended / 推奨** — latest |
-| `2.1.214` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.216` | ✅ **Recommended / 推奨** — latest |
+| `2.1.215` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.215 (Claude Code)
+2.1.216 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -544,7 +544,7 @@
       "entry_end_offset": 257798600,
       "tarball_integrity": "sha512-g2/K+v6MiIKY65SlPoFv8cRbRvroHxhvHPCf8lPDMMyRLG9fpHGGLZSR21W8OPjbqTZK8GcFcOaKrjQJrWveZw==",
       "tarball_sha256": "b95b5183b3e06ab23f8ea4d1d2781ea76640587251b8b710d6d981f22849c2ec",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.215",
+  "latest_audited_version": "2.1.216",
   "latest_candidate_version": "2.1.216",
-  "previous_stable_version": "2.1.214",
+  "previous_stable_version": "2.1.215",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.215
+npm install -g @bash0816/claude-code@2.1.216
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -544,7 +544,7 @@
       "entry_end_offset": 257798600,
       "tarball_integrity": "sha512-g2/K+v6MiIKY65SlPoFv8cRbRvroHxhvHPCf8lPDMMyRLG9fpHGGLZSR21W8OPjbqTZK8GcFcOaKrjQJrWveZw==",
       "tarball_sha256": "b95b5183b3e06ab23f8ea4d1d2781ea76640587251b8b710d6d981f22849c2ec",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.215",
+  "latest_audited_version": "2.1.216",
   "latest_candidate_version": "2.1.216",
-  "previous_stable_version": "2.1.214",
+  "previous_stable_version": "2.1.215",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
- G4 verification review (terra): Go
- Candidate publish complete, npm dist-tags.candidate=2.1.216 confirmed
- Device B verification passed (user-confirmed)
- Promotes 2.1.216 to termux_verified via `scripts/promote-verified-version.js`, refreshes manifest + README version guidance

Merging this to main will trigger `promote-and-publish.yml`, which retags npm `latest` (npm-publish Environment approval required, user only) and dispatches release-finalize.