### PR TITLE
chore: promote claude-code 2.1.217 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -553,7 +553,7 @@
       "entry_end_offset": 259020038,
       "tarball_integrity": "sha512-u0uRgmcZTL1vVQVvFbQ2GVjmmFQ+MhEGNrWaqm5xddqpVPE3RGVlm6wt1icMieV+wGdwCAzBNb89MeRM5giwzw==",
       "tarball_sha256": "665393be60778bb16427c2faff07778ccbea6d982ec883ecc767cf6a99c02ba3",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.216",
+  "latest_audited_version": "2.1.217",
   "latest_candidate_version": "2.1.217",
-  "previous_stable_version": "2.1.215",
+  "previous_stable_version": "2.1.216",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -553,7 +553,7 @@
       "entry_end_offset": 259020038,
       "tarball_integrity": "sha512-u0uRgmcZTL1vVQVvFbQ2GVjmmFQ+MhEGNrWaqm5xddqpVPE3RGVlm6wt1icMieV+wGdwCAzBNb89MeRM5giwzw==",
       "tarball_sha256": "665393be60778bb16427c2faff07778ccbea6d982ec883ecc767cf6a99c02ba3",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.216",
+  "latest_audited_version": "2.1.217",
   "latest_candidate_version": "2.1.217",
-  "previous_stable_version": "2.1.215",
+  "previous_stable_version": "2.1.216",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
- Device A (this machine) TUI verification: OK (user confirmed)
- Device B (separate device) verification: OK (user confirmed)
- Promotes `2.1.217` status `offset_discovered` → `termux_verified` in both audited-versions.json copies
- `latest_audited_version`: 2.1.216 → 2.1.217
- `previous_stable_version`: 2.1.215 → 2.1.216 (auto-computed by `scripts/update-release-manifest.js`)

Generated via `node scripts/promote-verified-version.js 2.1.217`.

## Next
Merging to main triggers `promote-and-publish.yml`, which will retag npm `latest` → 2.1.217 (requires `npm-publish` Environment approval by the user).