### PR TITLE
chore: promote claude-code 2.1.218 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -562,7 +562,7 @@
       "entry_end_offset": 263624682,
       "tarball_integrity": "sha512-CcbVQCzXd9EnlktCEPrkElhdBZuqIWhkeinRGxUuZa6aal4h6J+8Dbo+OnfchBEzd1mahRDQK8BckGBAYozv2g==",
       "tarball_sha256": "1d3cb5e12f0b653929e34ba046a7ba0a4f5c01eb25ea57b478dbac27e4af9619",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.217",
+  "latest_audited_version": "2.1.218",
   "latest_candidate_version": "2.1.218",
-  "previous_stable_version": "2.1.216",
+  "previous_stable_version": "2.1.217",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -562,7 +562,7 @@
       "entry_end_offset": 263624682,
       "tarball_integrity": "sha512-CcbVQCzXd9EnlktCEPrkElhdBZuqIWhkeinRGxUuZa6aal4h6J+8Dbo+OnfchBEzd1mahRDQK8BckGBAYozv2g==",
       "tarball_sha256": "1d3cb5e12f0b653929e34ba046a7ba0a4f5c01eb25ea57b478dbac27e4af9619",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.217",
+  "latest_audited_version": "2.1.218",
   "latest_candidate_version": "2.1.218",
-  "previous_stable_version": "2.1.216",
+  "previous_stable_version": "2.1.217",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
- Device A (このマシン) + Device B のTUI/install/auth検証OK申告を受け、2.1.218をtermux_verifiedへ昇格
- `node scripts/promote-verified-version.js 2.1.218` を実行し、manifest (`latest_audited_version`/`previous_stable_version`) を再計算

## Test plan
- [x] G4検証レビュー(GPT-5.6-terra)Go取得後にマージ