### PR TITLE
fix: bump Bun property access threshold to 42 for claude-code >=2.1.219

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -583,6 +583,7 @@ function rewriteNativeChunkSource(source) {
   const _bunPropertyAccessExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 219)) return 42;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 216)) return 40;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 214)) return 39;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 205)) return 38;
@@ -1275,6 +1276,7 @@ function rewriteNativeChunkSource(source) {
   const _bunPropertyAccessExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 219)) return 42;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 216)) return 40;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 214)) return 39;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 205)) return 38;

--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -478,6 +478,43 @@ test('rewriteNativeChunkSource rejects stale Bun property access count for versi
   }
 });
 
+test('rewriteNativeChunkSource rewrites the synthetic bundle slice (version 2.1.219)', () => {
+  process.env.CURRENT_CLAUDE_VERSION = '2.1.219';
+  try {
+    const { rewriteNativeChunkSource } = loadHelperApi();
+    const typeofBun = Array.from({ length: 7 }, () => 'typeof Bun').join('; ');
+    const bunProps = Array.from({ length: 42 }, (_, index) => `Bun.p${index}`).join('; ');
+    const source = `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0; npmInstallDeprecated:!0 }`;
+    const patched = rewriteNativeChunkSource(source);
+
+    assert.match(patched, /var __claudeBun = globalThis\.__claudeBunShim;/);
+    assert.match(patched, /typeof __claudeBun/);
+    assert.match(patched, /typeof globalThis\.__claudeBun/);
+    assert.match(patched, /globalThis\.__claudeBun/);
+    assert.match(patched, /__claudeBun\./);
+    assert.equal((patched.match(/__claudeBun\./g) || []).length, 42);
+  } finally {
+    delete process.env.CURRENT_CLAUDE_VERSION;
+  }
+});
+
+test('rewriteNativeChunkSource rejects stale Bun property access count for version 2.1.219', () => {
+  process.env.CURRENT_CLAUDE_VERSION = '2.1.219';
+  try {
+    const { rewriteNativeChunkSource } = loadHelperApi();
+    const typeofBun = Array.from({ length: 7 }, () => 'typeof Bun').join('; ');
+    const bunProps = Array.from({ length: 41 }, (_, index) => `Bun.p${index}`).join('; ');
+    const source = `function(exports, require, module, __filename, __dirname) { ${typeofBun}; typeof globalThis.Bun; globalThis.Bun; ${bunProps}; npmInstallDeprecated:!0; npmInstallDeprecated:!0 }`;
+
+    assert.throws(
+      () => rewriteNativeChunkSource(source),
+      /unexpected Bun property access count 41/,
+    );
+  } finally {
+    delete process.env.CURRENT_CLAUDE_VERSION;
+  }
+});
+
 test('rewriteNativeChunkSource rejects unexpected replacement counts', () => {
   const { rewriteNativeChunkSource } = loadHelperApi();
   const source = buildSyntheticBundleSource().replace('Bun.p30;', '');


### PR DESCRIPTION
## Summary
- 2.1.219's native bundle throws `unexpected Bun property access count 42` at the existing `>=216` threshold (40)
- Measured 42 via sequential-replacement simulation (matching `rewriteNativeChunkSource`'s actual replacement order), consistent with the runtime error
- `typeof Bun` (7) and `npmInstallDeprecated:!0` (2) counts unchanged from existing `>=200`/`>=203` branches
- Added `>=219` regression tests (success at 42, failure at 41) to both existing test patterns

## Test plan
- [x] `node --test lib/termux-run-claude-native.test.js` — 24/24 PASS
- [x] G1/G3/G4 review (GPT-5.6-terra) — G1/G3 Go, G4 No-Go pending TUI verification + auth status (in progress)
- [x] tgz install smoke test: `claude --version` → `2.1.219`, `claude -p "echo hello"` → `hello` (exit 0)
- [ ] TUI verification (user, in progress)