### PR TITLE
chore: promote claude-code 2.1.219 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.218
+npm install -g @bash0816/claude-code@2.1.219
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.218` | ✅ **Recommended / 推奨** — latest |
-| `2.1.217` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.219` | ✅ **Recommended / 推奨** — latest |
+| `2.1.218` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.218 (Claude Code)
+2.1.219 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -571,7 +571,7 @@
       "entry_end_offset": 265451802,
       "tarball_integrity": "sha512-G5yLidk2u6djL5PPuBYXVwVhTsZY5zLoZwh1Jnrd/IRyYb0P0x4gKTzVvGlsGepkBrOp0H2k/KuicyNPrXt57Q==",
       "tarball_sha256": "cf4ae671f08b91ac75ea63c8497e7ff4e3bdbe522b0f83bff2de162d44e0eb15",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.218",
+  "latest_audited_version": "2.1.219",
   "latest_candidate_version": "2.1.219",
-  "previous_stable_version": "2.1.217",
+  "previous_stable_version": "2.1.218",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.218
+npm install -g @bash0816/claude-code@2.1.219
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -571,7 +571,7 @@
       "entry_end_offset": 265451802,
       "tarball_integrity": "sha512-G5yLidk2u6djL5PPuBYXVwVhTsZY5zLoZwh1Jnrd/IRyYb0P0x4gKTzVvGlsGepkBrOp0H2k/KuicyNPrXt57Q==",
       "tarball_sha256": "cf4ae671f08b91ac75ea63c8497e7ff4e3bdbe522b0f83bff2de162d44e0eb15",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.218",
+  "latest_audited_version": "2.1.219",
   "latest_candidate_version": "2.1.219",
-  "previous_stable_version": "2.1.217",
+  "previous_stable_version": "2.1.218",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
- Device A (this machine) + Device B candidate検証OK(ユーザー申告)を受けてtermux_verifiedへ昇格
- \`node scripts/promote-verified-version.js 2.1.219\`実行、manifest/config両方(root+package)更新

## Test plan
- G4検証レビュー(2.1.219 candidate publish時点でGo済み、terraが実機native bundle照合済み)
- Device A/B candidate検証OK(ユーザー申告)

🤖 Generated with [Claude Code](https://claude.com/claude-code)