### PR TITLE
chore: promote claude-code 2.1.220 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -580,7 +580,7 @@
       "entry_end_offset": 265457701,
       "tarball_integrity": "sha512-VHFI8mKruIntKn7eq81sbyS19/KWmQcmJQsS/C+j9M/E+w0s4UytgsL7DADPjBE/GByNiKoRtLYDMntCjRlOdA==",
       "tarball_sha256": "e38454d73576a08a2e707f26539d73fc9ef33e890228ca5c58a2bbe810ac884d",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.219",
+  "latest_audited_version": "2.1.220",
   "latest_candidate_version": "2.1.220",
-  "previous_stable_version": "2.1.218",
+  "previous_stable_version": "2.1.219",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -580,7 +580,7 @@
       "entry_end_offset": 265457701,
       "tarball_integrity": "sha512-VHFI8mKruIntKn7eq81sbyS19/KWmQcmJQsS/C+j9M/E+w0s4UytgsL7DADPjBE/GByNiKoRtLYDMntCjRlOdA==",
       "tarball_sha256": "e38454d73576a08a2e707f26539d73fc9ef33e890228ca5c58a2bbe810ac884d",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.219",
+  "latest_audited_version": "2.1.220",
   "latest_candidate_version": "2.1.220",
-  "previous_stable_version": "2.1.218",
+  "previous_stable_version": "2.1.219",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Device A+B TUI検証OK(ユーザー申告)。node scripts/promote-verified-version.js 2.1.220 実行。