### PR TITLE
chore: advance candidate to 2.1.220-1

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -581,6 +581,15 @@
       "tarball_integrity": "sha512-VHFI8mKruIntKn7eq81sbyS19/KWmQcmJQsS/C+j9M/E+w0s4UytgsL7DADPjBE/GByNiKoRtLYDMntCjRlOdA==",
       "tarball_sha256": "e38454d73576a08a2e707f26539d73fc9ef33e890228ca5c58a2bbe810ac884d",
       "status": "termux_verified"
+    },
+    "2.1.220-1": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.220",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.220",
+      "entry_js_offset": 243831156,
+      "entry_end_offset": 265457701,
+      "tarball_integrity": "sha512-VHFI8mKruIntKn7eq81sbyS19/KWmQcmJQsS/C+j9M/E+w0s4UytgsL7DADPjBE/GByNiKoRtLYDMntCjRlOdA==",
+      "tarball_sha256": "e38454d73576a08a2e707f26539d73fc9ef33e890228ca5c58a2bbe810ac884d",
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.220",
-  "latest_candidate_version": "2.1.220",
+  "latest_candidate_version": "2.1.220-1",
   "previous_stable_version": "2.1.219",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -581,6 +581,15 @@
       "tarball_integrity": "sha512-VHFI8mKruIntKn7eq81sbyS19/KWmQcmJQsS/C+j9M/E+w0s4UytgsL7DADPjBE/GByNiKoRtLYDMntCjRlOdA==",
       "tarball_sha256": "e38454d73576a08a2e707f26539d73fc9ef33e890228ca5c58a2bbe810ac884d",
       "status": "termux_verified"
+    },
+    "2.1.220-1": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.220",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.220",
+      "entry_js_offset": 243831156,
+      "entry_end_offset": 265457701,
+      "tarball_integrity": "sha512-VHFI8mKruIntKn7eq81sbyS19/KWmQcmJQsS/C+j9M/E+w0s4UytgsL7DADPjBE/GByNiKoRtLYDMntCjRlOdA==",
+      "tarball_sha256": "e38454d73576a08a2e707f26539d73fc9ef33e890228ca5c58a2bbe810ac884d",
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.220",
-  "latest_candidate_version": "2.1.220",
+  "latest_candidate_version": "2.1.220-1",
   "previous_stable_version": "2.1.219",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.220",
+  "version": "2.1.220-1",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "GPL-3.0-only",
   "bin": {


### PR DESCRIPTION
## Summary
- Termux wrapper-only fix (stdin print flush wait, commit 02b2b28) already merged to main
- No upstream claude-code version change
- Adds 2.1.220-1 offset_discovered entry (same native binary/offsets as 2.1.220) to both audited-versions.json configs
- Bumps package.json and manifest latest_candidate_version to 2.1.220-1

## Test plan
- [ ] npm pack → tgz install → claude --version shows 2.1.220-1
- [ ] Device A / Device B verification per docs/release-process.md Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)