### PR TITLE
release: promote 2.1.220-2 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.220
+npm install -g @bash0816/claude-code@2.1.220-2
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.220` | ✅ **Recommended / 推奨** — latest |
-| `2.1.219` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.220-2` | ✅ **Recommended / 推奨** — latest |
+| `2.1.220` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.220 (Claude Code)
+2.1.220-2 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.220-2 (Claude Code)
+2.1.220 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -598,7 +598,7 @@
       "entry_end_offset": 265457701,
       "tarball_integrity": "sha512-VHFI8mKruIntKn7eq81sbyS19/KWmQcmJQsS/C+j9M/E+w0s4UytgsL7DADPjBE/GByNiKoRtLYDMntCjRlOdA==",
       "tarball_sha256": "e38454d73576a08a2e707f26539d73fc9ef33e890228ca5c58a2bbe810ac884d",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.220",
+  "latest_audited_version": "2.1.220-2",
   "latest_candidate_version": "2.1.220-2",
-  "previous_stable_version": "2.1.219",
+  "previous_stable_version": "2.1.220",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.220
+npm install -g @bash0816/claude-code@2.1.220-2
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -598,7 +598,7 @@
       "entry_end_offset": 265457701,
       "tarball_integrity": "sha512-VHFI8mKruIntKn7eq81sbyS19/KWmQcmJQsS/C+j9M/E+w0s4UytgsL7DADPjBE/GByNiKoRtLYDMntCjRlOdA==",
       "tarball_sha256": "e38454d73576a08a2e707f26539d73fc9ef33e890228ca5c58a2bbe810ac884d",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.220",
+  "latest_audited_version": "2.1.220-2",
   "latest_candidate_version": "2.1.220-2",
-  "previous_stable_version": "2.1.219",
+  "previous_stable_version": "2.1.220",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/scripts/update-readme-version-guidance.js
+++ b/scripts/update-readme-version-guidance.js
@@ -61,6 +61,11 @@ function formatTextBlock(lines) {
   return `\`\`\`text\n${lines.join('\n')}\n\`\`\``;
 }
 
+function extractNativeVersion(wrapperSpec) {
+  const idx = wrapperSpec.lastIndexOf('@');
+  return wrapperSpec.slice(idx + 1);
+}
+
 function renderInstallCommands(versions) {
   return versions.map(version => `npm install -g @bash0816/claude-code@${version}`);
 }
@@ -93,7 +98,7 @@ function updateSupportedVersionsTable(content, latestAudited, previousStable, st
   return content.slice(0, startIdx + tableStart.length) + tableSection + content.slice(endIdx);
 }
 
-function updateRootReadme(content, versions, latestAudited, previousStable, stablePinned) {
+function updateRootReadme(content, versions, latestAudited, previousStable, stablePinned, nativeVersion) {
   // Install command
   const installBlock = [
     formatShellBlock(renderInstallCommands([latestAudited])),
@@ -129,7 +134,7 @@ function updateRootReadme(content, versions, latestAudited, previousStable, stab
     '',
     '例:',
     '',
-    formatTextBlock([`${latestAudited} (Claude Code)`]),
+    formatTextBlock([`${nativeVersion} (Claude Code)`]),
     '',
   ].join('\n');
 
@@ -226,10 +231,13 @@ function main() {
     throw new Error('manifest latest audited version is not termux_verified');
   }
 
+  const latestAuditedEntry = rootConfig.versions[manifest.latest_audited_version];
+  const nativeVersion = extractNativeVersion(latestAuditedEntry.wrapper_spec);
+
   const rootReadme = fs.readFileSync(rootReadmeFile, 'utf8');
   const packageReadme = fs.readFileSync(packageReadmeFile, 'utf8');
 
-  fs.writeFileSync(rootReadmeFile, updateRootReadme(rootReadme, verifiedVersions, manifest.latest_audited_version, manifest.previous_stable_version, manifest.stable_pinned_version));
+  fs.writeFileSync(rootReadmeFile, updateRootReadme(rootReadme, verifiedVersions, manifest.latest_audited_version, manifest.previous_stable_version, manifest.stable_pinned_version, nativeVersion));
   fs.writeFileSync(packageReadmeFile, updatePackageReadme(packageReadme, verifiedVersions, manifest.latest_audited_version));
 }
 


### PR DESCRIPTION
## Summary
- Promotes `2.1.220-2` (process.kill self-SIGKILL interception fix, PR #253) from `offset_discovered` to `termux_verified`
- Updates manifest: `latest_audited_version` → `2.1.220-2`, `previous_stable_version` → `2.1.220`
- Updates README version references and Supported Versions table

## Test plan
- [x] Device A candidate install + smoke test (`claude --version` → 2.1.220, `claude -p "echo hello"` → exit 0)
- [x] Device A repro condition (CLAUDE_TERMUX_STDIN=inherit, PRINT_WAIT_MS=30000): 3/3 clean exits
- [x] Device B candidate install + smoke test (`claude --version` → 2.1.220, `claude -p "echo hello"` → exit 0)
- [x] Device B repro condition (same as Device A, stream-json verbose, wake-lock): 3/3 clean exits, no SIGKILL