### PR TITLE
fix: sync latest_candidate_version to 2.1.223-1 in release manifests

### DIFF
--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.223",
-  "latest_candidate_version": "2.1.223",
+  "latest_candidate_version": "2.1.223-1",
   "previous_stable_version": "2.1.222",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.223",
-  "latest_candidate_version": "2.1.223",
+  "latest_candidate_version": "2.1.223-1",
   "previous_stable_version": "2.1.222",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"


### PR DESCRIPTION
## Summary
Follow-up to #268. Both copies of `config/claude-termux-release-manifest.json` (repo root and `packages/claude-code/`) still had `latest_candidate_version: "2.1.223"` after the package.json bump to `2.1.223-1`, which caused `scripts/retag-latest-dist-tags.test.js` to fail in CI.

## Verification
- `node --test scripts/retag-latest-dist-tags.test.js`: 3/3 pass
- Full test suite (5 files, 98 tests): all pass