### PR TITLE
fix: add 2.1.223-1 entry to root claude-native-audited-versions.json

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -635,6 +635,15 @@
       "tarball_integrity": "sha512-gh0n3fvUgzsrjeTqZraOhDKOzS7afB9U/qFvRY0FBpccogbJCk8otTYavPfdhAA2xESAoA0BaoVdzO4k4VkphA==",
       "tarball_sha256": "29c49ec62bfbe995e5b1354a4c32d17101065d2c7722d5d0285cfa6a08d8c441",
       "status": "termux_verified"
+    },
+    "2.1.223-1": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.223",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.223",
+      "entry_js_offset": 257987828,
+      "entry_end_offset": 281109040,
+      "tarball_integrity": "sha512-gh0n3fvUgzsrjeTqZraOhDKOzS7afB9U/qFvRY0FBpccogbJCk8otTYavPfdhAA2xESAoA0BaoVdzO4k4VkphA==",
+      "tarball_sha256": "29c49ec62bfbe995e5b1354a4c32d17101065d2c7722d5d0285cfa6a08d8c441",
+      "status": "offset_discovered"
     }
   }
 }


### PR DESCRIPTION
## Summary
Second follow-up to #268. The repo-root mirror copy of `config/claude-native-audited-versions.json` was missing the `2.1.223-1` entry present in `packages/claude-code/config/claude-native-audited-versions.json`, causing `scripts/update-release-manifest.js`'s `assertSameVersions` check to fail in CI.

## Verification
- Full test suite (5 files, 98 tests): all pass
- `node scripts/update-release-manifest.js` run twice: second run produces zero diff (idempotent)