### PR TITLE
chore: promote claude-code 2.1.223-1 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.223
+npm install -g @bash0816/claude-code@2.1.223-1
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.223` | ✅ **Recommended / 推奨** — latest |
-| `2.1.222` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.223-1` | ✅ **Recommended / 推奨** — latest |
+| `2.1.223` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -643,7 +643,7 @@
       "entry_end_offset": 281109040,
       "tarball_integrity": "sha512-gh0n3fvUgzsrjeTqZraOhDKOzS7afB9U/qFvRY0FBpccogbJCk8otTYavPfdhAA2xESAoA0BaoVdzO4k4VkphA==",
       "tarball_sha256": "29c49ec62bfbe995e5b1354a4c32d17101065d2c7722d5d0285cfa6a08d8c441",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.223",
+  "latest_audited_version": "2.1.223-1",
   "latest_candidate_version": "2.1.223-1",
-  "previous_stable_version": "2.1.222",
+  "previous_stable_version": "2.1.223",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.223
+npm install -g @bash0816/claude-code@2.1.223-1
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -643,7 +643,7 @@
       "entry_end_offset": 281109040,
       "tarball_integrity": "sha512-gh0n3fvUgzsrjeTqZraOhDKOzS7afB9U/qFvRY0FBpccogbJCk8otTYavPfdhAA2xESAoA0BaoVdzO4k4VkphA==",
       "tarball_sha256": "29c49ec62bfbe995e5b1354a4c32d17101065d2c7722d5d0285cfa6a08d8c441",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.223",
+  "latest_audited_version": "2.1.223-1",
   "latest_candidate_version": "2.1.223-1",
-  "previous_stable_version": "2.1.222",
+  "previous_stable_version": "2.1.223",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
- Device B confirmed OK for 2.1.223-1
- Promotes status `offset_discovered` → `termux_verified` in both copies of `claude-native-audited-versions.json`
- `previous_stable_version` becomes `2.1.223`, `latest_audited_version` becomes `2.1.223-1`
- README updated via `scripts/update-readme-version-guidance.js`
- Note: this does NOT change npm's `latest` dist-tag (still 2.1.222). npm dist-tag promotion is a separate, deliberately deferred decision pending observation of daemon.log/jobs for interactiveLineage recurrence.

## Verification
- Full test suite (5 files, 98 tests): all pass
- Manifest generation scripts run twice: second run produces zero diff (idempotent)