### PR TITLE
Track claude-code 2.1.224 candidate

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -644,6 +644,15 @@
       "tarball_integrity": "sha512-gh0n3fvUgzsrjeTqZraOhDKOzS7afB9U/qFvRY0FBpccogbJCk8otTYavPfdhAA2xESAoA0BaoVdzO4k4VkphA==",
       "tarball_sha256": "29c49ec62bfbe995e5b1354a4c32d17101065d2c7722d5d0285cfa6a08d8c441",
       "status": "termux_verified"
+    },
+    "2.1.224": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.224",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.224",
+      "entry_js_offset": 262371668,
+      "entry_end_offset": 286057058,
+      "tarball_integrity": "sha512-a16Zlqhr1CXO5vsfsw7FcvLbG2nqBAXWmvMmyXtNW+f9pAJm91GMJE9wK79cIyO9InZRLN06wYWyPcp1cx/nNg==",
+      "tarball_sha256": "711712d0526f0b266c961a5591ddca55979cd581ac67b0a0ffd19e5f4e2df2c7",
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.223-1",
-  "latest_candidate_version": "2.1.223-1",
+  "latest_candidate_version": "2.1.224",
   "previous_stable_version": "2.1.223",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -644,6 +644,15 @@
       "tarball_integrity": "sha512-gh0n3fvUgzsrjeTqZraOhDKOzS7afB9U/qFvRY0FBpccogbJCk8otTYavPfdhAA2xESAoA0BaoVdzO4k4VkphA==",
       "tarball_sha256": "29c49ec62bfbe995e5b1354a4c32d17101065d2c7722d5d0285cfa6a08d8c441",
       "status": "termux_verified"
+    },
+    "2.1.224": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.224",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.224",
+      "entry_js_offset": 262371668,
+      "entry_end_offset": 286057058,
+      "tarball_integrity": "sha512-a16Zlqhr1CXO5vsfsw7FcvLbG2nqBAXWmvMmyXtNW+f9pAJm91GMJE9wK79cIyO9InZRLN06wYWyPcp1cx/nNg==",
+      "tarball_sha256": "711712d0526f0b266c961a5591ddca55979cd581ac67b0a0ffd19e5f4e2df2c7",
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.223-1",
-  "latest_candidate_version": "2.1.223-1",
+  "latest_candidate_version": "2.1.224",
   "previous_stable_version": "2.1.223",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -599,6 +599,7 @@ function rewriteNativeChunkSource(source) {
   const _bunPropertyAccessExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 224)) return 44;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 223)) return 43;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 219)) return 42;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 216)) return 40;
@@ -1477,6 +1478,7 @@ function rewriteNativeChunkSource(source) {
   const _bunPropertyAccessExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 224)) return 44;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 223)) return 43;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 219)) return 42;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 216)) return 40;

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.223-1",
+  "version": "2.1.224",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "GPL-3.0-only",
   "bin": {


### PR DESCRIPTION
## Summary
- Intake claude-code 2.1.224 candidate (offset_discovered)
- Add `_bunPropertyAccessExpected` >=224 return 44 ladder branch (both helper/bootstrap copies)
- Sync release manifest `latest_candidate_version` to 2.1.224 (`latest_audited_version` stays 2.1.223-1)

## Review
- G1 design review (GPT-5.6-terra): Go, no blockers
- G3 coding review (GPT-5.6-terra): Go, no blockers
- tgz smoke test on this machine: `claude --version` -> 2.1.224, `claude -p` responds correctly, `/background` disabled non-regression confirmed