### PR TITLE
chore: promote claude-code 2.1.224 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.223-1
+npm install -g @bash0816/claude-code@2.1.224
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.223-1` | ✅ **Recommended / 推奨** — latest |
-| `2.1.223` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.224` | ✅ **Recommended / 推奨** — latest |
+| `2.1.223-1` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.193` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.223 (Claude Code)
+2.1.224 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -652,7 +652,7 @@
       "entry_end_offset": 286057058,
       "tarball_integrity": "sha512-a16Zlqhr1CXO5vsfsw7FcvLbG2nqBAXWmvMmyXtNW+f9pAJm91GMJE9wK79cIyO9InZRLN06wYWyPcp1cx/nNg==",
       "tarball_sha256": "711712d0526f0b266c961a5591ddca55979cd581ac67b0a0ffd19e5f4e2df2c7",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.223-1",
+  "latest_audited_version": "2.1.224",
   "latest_candidate_version": "2.1.224",
-  "previous_stable_version": "2.1.223",
+  "previous_stable_version": "2.1.223-1",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.223-1
+npm install -g @bash0816/claude-code@2.1.224
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -652,7 +652,7 @@
       "entry_end_offset": 286057058,
       "tarball_integrity": "sha512-a16Zlqhr1CXO5vsfsw7FcvLbG2nqBAXWmvMmyXtNW+f9pAJm91GMJE9wK79cIyO9InZRLN06wYWyPcp1cx/nNg==",
       "tarball_sha256": "711712d0526f0b266c961a5591ddca55979cd581ac67b0a0ffd19e5f4e2df2c7",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.223-1",
+  "latest_audited_version": "2.1.224",
   "latest_candidate_version": "2.1.224",
-  "previous_stable_version": "2.1.223",
+  "previous_stable_version": "2.1.223-1",
   "stable_pinned_version": "2.1.193",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
- Promote claude-code 2.1.224 candidate to termux_verified (Device B OK confirmed by user)
- Regenerate release manifest via scripts/update-release-manifest.js (latest_audited_version -> 2.1.224, previous_stable_version -> 2.1.223-1)
- Regenerate README version guidance via scripts/update-readme-version-guidance.js

## Verification
- node --test (packages/claude-code): 92/92 pass
- Generator script idempotency confirmed (2 consecutive runs, zero diff)
- This promotion does NOT change npm dist-tags (latest stays untouched, separate track)