### PR TITLE
test: isolate CLAUDE_CODE_DISABLE_AGENT_VIEW from ambient environment

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -13,6 +13,11 @@ const vm = require('vm');
 const scriptPath = path.join(__dirname, 'termux-run-claude-native.sh');
 const script = fs.readFileSync(scriptPath, 'utf8');
 
+// Fixtures below don't include the /background isEnabled pattern, so
+// rewriteNativeChunkSource must run with the patch disabled (its default)
+// regardless of what the ambient shell happens to export.
+delete process.env.CLAUDE_CODE_DISABLE_AGENT_VIEW;
+
 function extractBlock(marker, trailer) {
   const start = script.indexOf(marker);
   assert.notEqual(start, -1, `missing marker: ${marker}`);


### PR DESCRIPTION
## Summary
- termux-run-claude-native.test.js fixtures don't include the /background isEnabled pattern, so rewriteNativeChunkSource must run with the patch disabled by default
- Explicitly clear CLAUDE_CODE_DISABLE_AGENT_VIEW at module load so ambient shell state can't leak into the test run and cause spurious failures across ~28 unrelated tests

## Verification
- Before fix, with CLAUDE_CODE_DISABLE_AGENT_VIEW=1 injected: 60 tests, 32 pass, 28 fail
- After fix, same polluted env: 60 tests, 59 pass, 0 fail, 1 skip
- After fix, clean env and env -u: same result (60 tests, 59 pass, 0 fail, 1 skip)
- G3 coding review (GPT-5.6-terra): Go, no blockers