### PR TITLE
chore: sync stable_pinned_version metadata to 2.1.220-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Only versions registered in the audited metadata can run.
 |---------|--------|
 | `2.1.224` | ✅ **Recommended / 推奨** — latest |
 | `2.1.223-1` | ✅ rollback candidate — `@candidate` dist-tag |
-| `2.1.193` | ✅ stable — `@stable` dist-tag |
+| `2.1.220-2` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
 ### Fable 5 Model Fix / Fable 5 モデル選択肢修正

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -4,6 +4,6 @@
   "latest_audited_version": "2.1.224",
   "latest_candidate_version": "2.1.224",
   "previous_stable_version": "2.1.223-1",
-  "stable_pinned_version": "2.1.193",
+  "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -4,6 +4,6 @@
   "latest_audited_version": "2.1.224",
   "latest_candidate_version": "2.1.224",
   "previous_stable_version": "2.1.223-1",
-  "stable_pinned_version": "2.1.193",
+  "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
- Sync stable_pinned_version in both release manifests to 2.1.220-2 (matches the already-completed npm `stable` dist-tag retag)
- Regenerate README Supported Versions table via scripts/update-readme-version-guidance.js

## Verification
- npm dist-tags already show stable: "2.1.220-2" (retagged and approved separately)
- node --test (packages/claude-code): 91/91 pass, 1 skip (tgz-dependent, expected)