### PR TITLE
Track claude-code 2.1.226 candidate

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -653,6 +653,15 @@
       "tarball_integrity": "sha512-a16Zlqhr1CXO5vsfsw7FcvLbG2nqBAXWmvMmyXtNW+f9pAJm91GMJE9wK79cIyO9InZRLN06wYWyPcp1cx/nNg==",
       "tarball_sha256": "711712d0526f0b266c961a5591ddca55979cd581ac67b0a0ffd19e5f4e2df2c7",
       "status": "termux_verified"
+    },
+    "2.1.226": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.226",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.226",
+      "entry_js_offset": 264236564,
+      "entry_end_offset": 288213155,
+      "tarball_integrity": "sha512-/USq3R28PunkjZZfyweEgUAlR7npgrruZmb47j3oRRxlFWk5Jurj+THiwhl/AKxUgkxaxb35cr6DCAeXNlQ/jg==",
+      "tarball_sha256": "fbbb2610daff70d118c8dda8aeffee92b38f20aa464e758c3d09e3c83ab6ef56",
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.224",
-  "latest_candidate_version": "2.1.224",
+  "latest_candidate_version": "2.1.226",
   "previous_stable_version": "2.1.223-1",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -653,6 +653,15 @@
       "tarball_integrity": "sha512-a16Zlqhr1CXO5vsfsw7FcvLbG2nqBAXWmvMmyXtNW+f9pAJm91GMJE9wK79cIyO9InZRLN06wYWyPcp1cx/nNg==",
       "tarball_sha256": "711712d0526f0b266c961a5591ddca55979cd581ac67b0a0ffd19e5f4e2df2c7",
       "status": "termux_verified"
+    },
+    "2.1.226": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.226",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.226",
+      "entry_js_offset": 264236564,
+      "entry_end_offset": 288213155,
+      "tarball_integrity": "sha512-/USq3R28PunkjZZfyweEgUAlR7npgrruZmb47j3oRRxlFWk5Jurj+THiwhl/AKxUgkxaxb35cr6DCAeXNlQ/jg==",
+      "tarball_sha256": "fbbb2610daff70d118c8dda8aeffee92b38f20aa464e758c3d09e3c83ab6ef56",
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.224",
-  "latest_candidate_version": "2.1.224",
+  "latest_candidate_version": "2.1.226",
   "previous_stable_version": "2.1.223-1",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.224",
+  "version": "2.1.226",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "GPL-3.0-only",
   "bin": {


### PR DESCRIPTION
## Summary
- Intake claude-code 2.1.226 candidate (offset_discovered)
- No logic changes to termux-run-claude-native.sh: actual rewriteNativeChunkSource function evaluated against the real 2.1.226 binary completes without throwing, existing `>=224 return 44` threshold already covers it
- Sync release manifest `latest_candidate_version` to 2.1.226 (`latest_audited_version` stays 2.1.224)

## Review
- G1+G3 combined review (GPT-5.6-terra): content Non-blocker/clean, only procedural blocker was working directly on main (now resolved via this branch)
- tgz smoke test on this machine: `claude --version` -> 2.1.226, `claude -p` responds correctly
- node --test: 91/91 pass, 1 skip (tgz-dependent, expected)