### PR TITLE
Promote claude-code 2.1.226 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.224
+npm install -g @bash0816/claude-code@2.1.226
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.224` | ✅ **Recommended / 推奨** — latest |
-| `2.1.223-1` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.226` | ✅ **Recommended / 推奨** — latest |
+| `2.1.224` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.220-2` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.224 (Claude Code)
+2.1.226 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -661,7 +661,7 @@
       "entry_end_offset": 288213155,
       "tarball_integrity": "sha512-/USq3R28PunkjZZfyweEgUAlR7npgrruZmb47j3oRRxlFWk5Jurj+THiwhl/AKxUgkxaxb35cr6DCAeXNlQ/jg==",
       "tarball_sha256": "fbbb2610daff70d118c8dda8aeffee92b38f20aa464e758c3d09e3c83ab6ef56",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.224",
+  "latest_audited_version": "2.1.226",
   "latest_candidate_version": "2.1.226",
-  "previous_stable_version": "2.1.223-1",
+  "previous_stable_version": "2.1.224",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.224
+npm install -g @bash0816/claude-code@2.1.226
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -661,7 +661,7 @@
       "entry_end_offset": 288213155,
       "tarball_integrity": "sha512-/USq3R28PunkjZZfyweEgUAlR7npgrruZmb47j3oRRxlFWk5Jurj+THiwhl/AKxUgkxaxb35cr6DCAeXNlQ/jg==",
       "tarball_sha256": "fbbb2610daff70d118c8dda8aeffee92b38f20aa464e758c3d09e3c83ab6ef56",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.224",
+  "latest_audited_version": "2.1.226",
   "latest_candidate_version": "2.1.226",
-  "previous_stable_version": "2.1.223-1",
+  "previous_stable_version": "2.1.224",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary

- Status field changed: `offset_discovered` → `termux_verified` for version 2.1.226
- Automated updates via `npm run compile-config` and `npm run update-readme`
- Test result: 91 pass / 0 fail / 1 skip (node --test)

## Verification

All version configurations and README files have been automatically updated to reflect the new status.
