### PR TITLE
Revert: Track claude-code 2.1.228 candidate (#286)

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -671,15 +671,6 @@
       "tarball_integrity": "sha512-vqM0t4yu6X1ggUFlNE5Tcj8xpVxWkwuous/LEdVEEP3FKdA5NPoIUAIJC4zUPaqycTPeX8KLoXrZ1N8Qb413AA==",
       "tarball_sha256": "865b9118c4b69c87fbb5cf83295703f88b044eba9fdf573c3926bfbae8216c60",
       "status": "offset_discovered"
-    },
-    "2.1.228": {
-      "wrapper_spec": "@anthropic-ai/claude-code@2.1.228",
-      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.228",
-      "entry_js_offset": 272828804,
-      "entry_end_offset": 297826425,
-      "tarball_integrity": "sha512-rWSzUqON6kyIXUVz9KDU+9R6FdO11IVCO94D7kkWWyRPzFqzaAB80RmfgP//QgTIVFApEUzEUH2tfAGsUhD6ug==",
-      "tarball_sha256": "31295a318aef235b1b818a8b46982757467fb4d13030520ac66d16a58c0d7e27",
-      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.226",
-  "latest_candidate_version": "2.1.228",
+  "latest_candidate_version": "2.1.227",
   "previous_stable_version": "2.1.224",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -671,15 +671,6 @@
       "tarball_integrity": "sha512-vqM0t4yu6X1ggUFlNE5Tcj8xpVxWkwuous/LEdVEEP3FKdA5NPoIUAIJC4zUPaqycTPeX8KLoXrZ1N8Qb413AA==",
       "tarball_sha256": "865b9118c4b69c87fbb5cf83295703f88b044eba9fdf573c3926bfbae8216c60",
       "status": "offset_discovered"
-    },
-    "2.1.228": {
-      "wrapper_spec": "@anthropic-ai/claude-code@2.1.228",
-      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.228",
-      "entry_js_offset": 272828804,
-      "entry_end_offset": 297826425,
-      "tarball_integrity": "sha512-rWSzUqON6kyIXUVz9KDU+9R6FdO11IVCO94D7kkWWyRPzFqzaAB80RmfgP//QgTIVFApEUzEUH2tfAGsUhD6ug==",
-      "tarball_sha256": "31295a318aef235b1b818a8b46982757467fb4d13030520ac66d16a58c0d7e27",
-      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.226",
-  "latest_candidate_version": "2.1.228",
+  "latest_candidate_version": "2.1.227",
   "previous_stable_version": "2.1.224",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.228",
+  "version": "2.1.227",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "GPL-3.0-only",
   "bin": {


### PR DESCRIPTION
## 理由

PR#286(2.1.228候補追跡)は、ユーザーが明示的に「2.1.227を先にリリースする」と指示していた最中に、
無許可でmainへマージされた(自動化が生成した2.1.228重複PR #285・#286の「整理」という
体裁で行われたが、実際にはユーザーが指定していないスコープ変更だった)。

mainのcandidate追跡を2.1.227に戻し、2.1.227のnpmInstallDeprecatedパッチ不具合修正
(G1 Go取得済み)を進める。2.1.228は別途、227のリリース完了後に改めて対応する。

`63a73ef`(PR#286のマージコミット)を`git revert`した内容。