### PR TITLE
fix: skip npmInstallDeprecated patch for claude-code 2.1.227+

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -619,16 +619,19 @@ function rewriteNativeChunkSource(source) {
   const _npmInstallDeprecatedExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 227)) return 0;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 203)) return 2;
     return 1;
   })();
-  patched = replaceRequired(
-    patched,
-    /\bnpmInstallDeprecated:!0\b/g,
-    'npmInstallDeprecated:!1',
-    'npmInstallDeprecated flag',
-    _npmInstallDeprecatedExpected,
-  );
+  if (_npmInstallDeprecatedExpected > 0) {
+    patched = replaceRequired(
+      patched,
+      /\bnpmInstallDeprecated:!0\b/g,
+      'npmInstallDeprecated:!1',
+      'npmInstallDeprecated flag',
+      _npmInstallDeprecatedExpected,
+    );
+  }
   patched = replaceRequired(
     patched,
     /function ([A-Za-z_$][\w$]*)\(\)\{(return\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\)=>\{let\{cmd:([A-Za-z_$][\w$]*),prefixArgs:([A-Za-z_$][\w$]*)\}=[A-Za-z_$][\w$]*\(\{pinToCurrentBinary:!0\}\),[A-Za-z_$][\w$]*=\[\3,\.\.\.\4,"--bg-pty-host")/g,
@@ -1498,16 +1501,19 @@ function rewriteNativeChunkSource(source) {
   const _npmInstallDeprecatedExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 227)) return 0;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 203)) return 2;
     return 1;
   })();
-  patched = replaceRequired(
-    patched,
-    /\bnpmInstallDeprecated:!0\b/g,
-    'npmInstallDeprecated:!1',
-    'npmInstallDeprecated flag',
-    _npmInstallDeprecatedExpected,
-  );
+  if (_npmInstallDeprecatedExpected > 0) {
+    patched = replaceRequired(
+      patched,
+      /\bnpmInstallDeprecated:!0\b/g,
+      'npmInstallDeprecated:!1',
+      'npmInstallDeprecated flag',
+      _npmInstallDeprecatedExpected,
+    );
+  }
   patched = replaceRequired(
     patched,
     /function ([A-Za-z_$][\w$]*)\(\)\{(return\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\)=>\{let\{cmd:([A-Za-z_$][\w$]*),prefixArgs:([A-Za-z_$][\w$]*)\}=[A-Za-z_$][\w$]*\(\{pinToCurrentBinary:!0\}\),[A-Za-z_$][\w$]*=\[\3,\.\.\.\4,"--bg-pty-host")/g,


### PR DESCRIPTION
## 背景

claude-code 2.1.227で、`termux-run-claude-native.sh`が依存する`npmInstallDeprecated:!0`
という文字列がupstream側から完全に削除されており、既存の`replaceRequired()`が
マッチ0件で例外を投げるため`claude`コマンド自体が起動不能(exit 1)になっていた。

## 修正内容

`_npmInstallDeprecatedExpected`の算出ロジックに`>= 227`判定を追加し期待マッチ数を0に、
続く`replaceRequired`呼び出し自体を条件付きスキップするよう変更(ファイル内に重複して
存在する2箇所とも同様に修正)。

## 検証

- 実バイナリ2.1.227・2.1.228を実際にnpm packで取得し、全パッチ対象パターンを
  順次シミュレーションで検証(`npmInstallDeprecated`のみ0件、他は全て既存期待値と一致)。
- `npm pack`→`npm install -g`のtgzスモークテスト: `claude --version`(2.1.227、exit 0)・
  `claude -p`(正答、exit 0)ともに成功、修正前のクラッシュが解消。
- G1(3回、GPT-5.6-terra)・G3(GPT-5.6-terra)いずれもGo(ブロッカーなし)。

## Non-blocker(別途対応)

- 2.1.227固有の回帰テストは未追加(既存60テストは全PASS)。