### PR TITLE
chore: promote claude-code 2.1.227 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.226
+npm install -g @bash0816/claude-code@2.1.227
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.226` | ✅ **Recommended / 推奨** — latest |
-| `2.1.224` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.227` | ✅ **Recommended / 推奨** — latest |
+| `2.1.226` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.220-2` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -143,7 +143,7 @@ Example:
 例:
 
 ```text
-2.1.226 (Claude Code)
+2.1.227 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -670,7 +670,7 @@
       "entry_end_offset": 293584486,
       "tarball_integrity": "sha512-vqM0t4yu6X1ggUFlNE5Tcj8xpVxWkwuous/LEdVEEP3FKdA5NPoIUAIJC4zUPaqycTPeX8KLoXrZ1N8Qb413AA==",
       "tarball_sha256": "865b9118c4b69c87fbb5cf83295703f88b044eba9fdf573c3926bfbae8216c60",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.226",
+  "latest_audited_version": "2.1.227",
   "latest_candidate_version": "2.1.227",
-  "previous_stable_version": "2.1.224",
+  "previous_stable_version": "2.1.226",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.226
+npm install -g @bash0816/claude-code@2.1.227
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -670,7 +670,7 @@
       "entry_end_offset": 293584486,
       "tarball_integrity": "sha512-vqM0t4yu6X1ggUFlNE5Tcj8xpVxWkwuous/LEdVEEP3FKdA5NPoIUAIJC4zUPaqycTPeX8KLoXrZ1N8Qb413AA==",
       "tarball_sha256": "865b9118c4b69c87fbb5cf83295703f88b044eba9fdf573c3926bfbae8216c60",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.226",
+  "latest_audited_version": "2.1.227",
   "latest_candidate_version": "2.1.227",
-  "previous_stable_version": "2.1.224",
+  "previous_stable_version": "2.1.226",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary

Promote version 2.1.227 from offset discovery to audited (termux_verified) status.

- Updated `config/claude-native-audited-versions.json` status field
- Updated `config/claude-termux-release-manifest.json` latest_audited_version and previous_stable_version
- Updated `packages/claude-code/config/` files accordingly
- Updated README.md and packages/claude-code/README.md version guidance tables

## Test Results

All 92 unit tests passing:
```
ℹ tests 92
ℹ pass 92
ℹ fail 0
```

## Notes

- This is a repository metadata promotion only
- **No npm dist-tag changes** are made (candidate remains at @candidate)
- This follows the same pattern as PR#267, PR#273, and PR#282
- The scripts (`promote-verified-version.js` and `update-readme-version-guidance.js`) are deterministic and audit-ready