### PR TITLE
fix: detect completion in plain -p mode via stdout write watcher (issue #18)

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -680,6 +680,58 @@ async function main() {
   }
   const printWaitMs = Number(process.env.CLAUDE_TERMUX_PRINT_WAIT_MS || 5000);
 
+  function installPlainTextWriteWatcher() {
+    const hadOwnWrite = Object.prototype.hasOwnProperty.call(process.stdout, 'write');
+    const originalWriteDescriptor = hadOwnWrite ? Object.getOwnPropertyDescriptor(process.stdout, 'write') : undefined;
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    let foundOutput = false;
+    let resultPromiseResolve = null;
+    let restored = false;
+
+    process.stdout.write = function wrappedWrite(chunk, encoding, callback) {
+      let cb = callback;
+      let enc = encoding;
+      if (typeof encoding === 'function') {
+        cb = encoding;
+        enc = undefined;
+      }
+      const combinedCallback = (err) => {
+        if (!err && !foundOutput) {
+          const len = typeof chunk === 'string'
+            ? Buffer.byteLength(chunk, typeof enc === 'string' ? enc : 'utf8')
+            : (Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk ?? ''), 'utf8'));
+          if (len > 0) {
+            foundOutput = true;
+            if (typeof resultPromiseResolve === 'function') resultPromiseResolve();
+          }
+        }
+        if (typeof cb === 'function') cb(err);
+      };
+      return originalWrite(chunk, enc, combinedCallback);
+    };
+
+    return {
+      waitForResult() {
+        if (foundOutput) return Promise.resolve();
+        return new Promise((resolve) => {
+          resultPromiseResolve = resolve;
+        });
+      },
+      hasOutput() {
+        return foundOutput;
+      },
+      restore() {
+        if (restored) return;
+        restored = true;
+        if (hadOwnWrite) {
+          Object.defineProperty(process.stdout, 'write', originalWriteDescriptor);
+        } else {
+          delete process.stdout.write;
+        }
+      },
+    };
+  }
+
   function installStreamJsonTerminalWatcher() {
     const hadOwnWrite = Object.prototype.hasOwnProperty.call(process.stdout, 'write');
     const originalWriteDescriptor = hadOwnWrite ? Object.getOwnPropertyDescriptor(process.stdout, 'write') : undefined;
@@ -765,6 +817,25 @@ async function main() {
       if (timedOut) {
         forceTimeoutExit(1);
         return;
+      }
+      return;
+    }
+    if (streamJsonWatcher && typeof streamJsonWatcher.hasOutput === 'function') {
+      if (streamJsonWatcher.hasOutput()) {
+        return;
+      }
+      const gatingExitCode = process.exitCode;
+      const rawResultTimeoutMs = Number(process.env.CLAUDE_TERMUX_PRINT_RESULT_TIMEOUT_MS);
+      const extendedTimeoutMs = (Number.isFinite(rawResultTimeoutMs) && rawResultTimeoutMs > 0) ? rawResultTimeoutMs : 300000;
+      const noOutputTimeoutMs = (gatingExitCode !== undefined && gatingExitCode !== 0) ? printWaitMs : extendedTimeoutMs;
+      let timeoutHandle;
+      const timeoutPromise = new Promise(resolve => {
+        timeoutHandle = setTimeout(resolve, noOutputTimeoutMs);
+      });
+      try {
+        await Promise.race([streamJsonWatcher.waitForResult(), timeoutPromise]);
+      } finally {
+        clearTimeout(timeoutHandle);
       }
       return;
     }
@@ -882,6 +953,8 @@ async function main() {
 
     if (isStreamJsonPrintMode(argv)) {
       streamJsonWatcher = installStreamJsonTerminalWatcher();
+    } else {
+      streamJsonWatcher = installPlainTextWriteWatcher();
     }
 
     const moduleLike = { exports: {} };
@@ -1561,6 +1634,58 @@ async function main() {
     asyncErrors.push(error);
   }
 
+  function installPlainTextWriteWatcher() {
+    const hadOwnWrite = Object.prototype.hasOwnProperty.call(process.stdout, 'write');
+    const originalWriteDescriptor = hadOwnWrite ? Object.getOwnPropertyDescriptor(process.stdout, 'write') : undefined;
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    let foundOutput = false;
+    let resultPromiseResolve = null;
+    let restored = false;
+
+    process.stdout.write = function wrappedWrite(chunk, encoding, callback) {
+      let cb = callback;
+      let enc = encoding;
+      if (typeof encoding === 'function') {
+        cb = encoding;
+        enc = undefined;
+      }
+      const combinedCallback = (err) => {
+        if (!err && !foundOutput) {
+          const len = typeof chunk === 'string'
+            ? Buffer.byteLength(chunk, typeof enc === 'string' ? enc : 'utf8')
+            : (Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk ?? ''), 'utf8'));
+          if (len > 0) {
+            foundOutput = true;
+            if (typeof resultPromiseResolve === 'function') resultPromiseResolve();
+          }
+        }
+        if (typeof cb === 'function') cb(err);
+      };
+      return originalWrite(chunk, enc, combinedCallback);
+    };
+
+    return {
+      waitForResult() {
+        if (foundOutput) return Promise.resolve();
+        return new Promise((resolve) => {
+          resultPromiseResolve = resolve;
+        });
+      },
+      hasOutput() {
+        return foundOutput;
+      },
+      restore() {
+        if (restored) return;
+        restored = true;
+        if (hadOwnWrite) {
+          Object.defineProperty(process.stdout, 'write', originalWriteDescriptor);
+        } else {
+          delete process.stdout.write;
+        }
+      },
+    };
+  }
+
   function installStreamJsonTerminalWatcher() {
     const hadOwnWrite = Object.prototype.hasOwnProperty.call(process.stdout, 'write');
     const originalWriteDescriptor = hadOwnWrite ? Object.getOwnPropertyDescriptor(process.stdout, 'write') : undefined;
@@ -1647,6 +1772,26 @@ async function main() {
       if (timedOut) {
         forceTimeoutExit(1);
         return;
+      }
+      return;
+    }
+    if (streamJsonWatcher && typeof streamJsonWatcher.hasOutput === 'function') {
+      if (streamJsonWatcher.hasOutput()) {
+        return;
+      }
+      const printWaitMs = Number(process.env.CLAUDE_TERMUX_PRINT_WAIT_MS || 5000);
+      const gatingExitCode = process.exitCode;
+      const rawResultTimeoutMs = Number(process.env.CLAUDE_TERMUX_PRINT_RESULT_TIMEOUT_MS);
+      const extendedTimeoutMs = (Number.isFinite(rawResultTimeoutMs) && rawResultTimeoutMs > 0) ? rawResultTimeoutMs : 300000;
+      const noOutputTimeoutMs = (gatingExitCode !== undefined && gatingExitCode !== 0) ? printWaitMs : extendedTimeoutMs;
+      let timeoutHandle;
+      const timeoutPromise = new Promise(resolve => {
+        timeoutHandle = setTimeout(resolve, noOutputTimeoutMs);
+      });
+      try {
+        await Promise.race([streamJsonWatcher.waitForResult(), timeoutPromise]);
+      } finally {
+        clearTimeout(timeoutHandle);
       }
       return;
     }
@@ -1765,6 +1910,8 @@ async function main() {
 
     if (isStreamJsonPrintMode(argv)) {
       streamJsonWatcher = installStreamJsonTerminalWatcher();
+    } else if (process.env.CLAUDE_TERMUX_PRINT_MODE === '1') {
+      streamJsonWatcher = installPlainTextWriteWatcher();
     }
 
     const moduleLike = { exports: {} };

--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -717,11 +717,14 @@ function buildScenarioFixtureSource() {
       process.exitCode = 1;
       return;
     }
+    if (scenario === 'plain-no-output-success') {
+      return;
+    }
     process.stdout.write('ok');
   }`;
 }
 
-function runScenario({ printMode, stdinInherit, scenario, extraArgs }) {
+function runScenario({ printMode, stdinInherit, scenario, extraArgs, extraEnv }) {
   const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-stdin-test-'));
   const sourceBin = path.join(tmpBase, 'fake-source.js');
   const fixtureSource = buildScenarioFixtureSource();
@@ -743,6 +746,7 @@ function runScenario({ printMode, stdinInherit, scenario, extraArgs }) {
     CLAUDE_TERMUX_PRINT_WAIT_MS: '300',
     TMPDIR: tmpBase,
     TEST_SCENARIO: scenario,
+    ...(extraEnv || {}),
   };
   if (stdinInherit) env.CLAUDE_TERMUX_STDIN = 'inherit';
   else delete env.CLAUDE_TERMUX_STDIN;
@@ -860,6 +864,36 @@ test('bootstrap branch plain mode with no output and non-zero exitCode exits pro
   try {
     assert.equal(r.status, 1, `status=${r.status} stderr=${r.stderr}`);
     assert.ok(r.elapsedMs < 5000, `expected prompt exit, got elapsedMs=${r.elapsedMs}`);
+  } finally {
+    fs.rmSync(r.tmpBase, { recursive: true, force: true });
+  }
+});
+
+test('helper branch plain mode with no output and successful exit waits up to configured ceiling', () => {
+  const r = runScenario({
+    printMode: true,
+    stdinInherit: false,
+    scenario: 'plain-no-output-success',
+    extraEnv: { CLAUDE_TERMUX_PRINT_RESULT_TIMEOUT_MS: '400' },
+  });
+  try {
+    assert.equal(r.status, 0, `status=${r.status} stderr=${r.stderr}`);
+    assert.ok(r.elapsedMs >= 350, `expected extended wait close to 400ms ceiling, got elapsedMs=${r.elapsedMs}`);
+  } finally {
+    fs.rmSync(r.tmpBase, { recursive: true, force: true });
+  }
+});
+
+test('bootstrap branch plain mode with no output and successful exit waits up to configured ceiling', () => {
+  const r = runScenario({
+    printMode: true,
+    stdinInherit: true,
+    scenario: 'plain-no-output-success',
+    extraEnv: { CLAUDE_TERMUX_PRINT_RESULT_TIMEOUT_MS: '400' },
+  });
+  try {
+    assert.equal(r.status, 0, `status=${r.status} stderr=${r.stderr}`);
+    assert.ok(r.elapsedMs >= 350, `expected extended wait close to 400ms ceiling, got elapsedMs=${r.elapsedMs}`);
   } finally {
     fs.rmSync(r.tmpBase, { recursive: true, force: true });
   }
@@ -1121,6 +1155,31 @@ test('helper and bootstrap installStreamJsonTerminalWatcher helpers stay identic
   );
 
   assert.equal(helperWatcher, bootstrapWatcher, 'installStreamJsonTerminalWatcher must be identical in both heredocs');
+});
+
+test('helper and bootstrap installPlainTextWriteWatcher helpers stay identical', () => {
+  const helperBlock = extractBlock('cat <<\'NODE\' > "$_helper"', '\n  export ENABLE_CLAUDEAI_MCP_SERVERS=');
+  const bootstrapBlock = extractBlock('cat <<\'NODE\' > "$_bootstrap"', '\n  export ENABLE_CLAUDEAI_MCP_SERVERS=');
+
+  const extractFn = (block) => {
+    const startMarker = 'function installPlainTextWriteWatcher() {';
+    const start = block.indexOf(startMarker);
+    assert.ok(start > -1, 'installPlainTextWriteWatcher function not found');
+    let depth = 0;
+    let i = start + startMarker.length - 1;
+    for (; i < block.length; i++) {
+      if (block[i] === '{') depth++;
+      if (block[i] === '}') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    return block.slice(start, i + 1);
+  };
+
+  const helperFn = extractFn(helperBlock);
+  const bootstrapFn = extractFn(bootstrapBlock);
+  assert.equal(helperFn, bootstrapFn, 'installPlainTextWriteWatcher must be identical in helper and bootstrap');
 });
 
 test('helper and bootstrap forceTimeoutExit helpers stay identical', () => {

--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -709,6 +709,14 @@ function buildScenarioFixtureSource() {
       process.exit(0);
       return;
     }
+    if (scenario === 'plain-late-write') {
+      setTimeout(() => { process.stdout.write('late-output'); }, 800);
+      return;
+    }
+    if (scenario === 'plain-no-output-error') {
+      process.exitCode = 1;
+      return;
+    }
     process.stdout.write('ok');
   }`;
 }
@@ -814,6 +822,46 @@ test('bootstrap branch (-p + CLAUDE_TERMUX_STDIN=inherit): normal/sync-exit/asyn
     } finally {
       fs.rmSync(r.tmpBase, { recursive: true, force: true });
     }
+  }
+});
+
+test('helper branch plain mode waits for late write beyond default printWaitMs', () => {
+  const r = runScenario({ printMode: true, stdinInherit: false, scenario: 'plain-late-write' });
+  try {
+    assert.ok((r.stdout || '').includes('late-output'), `stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.equal(r.status, 0, `status=${r.status} stderr=${r.stderr}`);
+  } finally {
+    fs.rmSync(r.tmpBase, { recursive: true, force: true });
+  }
+});
+
+test('bootstrap branch plain mode waits for late write beyond default printWaitMs', () => {
+  const r = runScenario({ printMode: true, stdinInherit: true, scenario: 'plain-late-write' });
+  try {
+    assert.ok((r.stdout || '').includes('late-output'), `stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.equal(r.status, 0, `status=${r.status} stderr=${r.stderr}`);
+  } finally {
+    fs.rmSync(r.tmpBase, { recursive: true, force: true });
+  }
+});
+
+test('helper branch plain mode with no output and non-zero exitCode exits promptly (no extended wait)', () => {
+  const r = runScenario({ printMode: true, stdinInherit: false, scenario: 'plain-no-output-error' });
+  try {
+    assert.equal(r.status, 1, `status=${r.status} stderr=${r.stderr}`);
+    assert.ok(r.elapsedMs < 5000, `expected prompt exit, got elapsedMs=${r.elapsedMs}`);
+  } finally {
+    fs.rmSync(r.tmpBase, { recursive: true, force: true });
+  }
+});
+
+test('bootstrap branch plain mode with no output and non-zero exitCode exits promptly (no extended wait)', () => {
+  const r = runScenario({ printMode: true, stdinInherit: true, scenario: 'plain-no-output-error' });
+  try {
+    assert.equal(r.status, 1, `status=${r.status} stderr=${r.stderr}`);
+    assert.ok(r.elapsedMs < 5000, `expected prompt exit, got elapsedMs=${r.elapsedMs}`);
+  } finally {
+    fs.rmSync(r.tmpBase, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- Fixes bash0816/CluadeCode-Termux-private#18 (plain `-p` mode silent exit when the actual API round-trip exceeds the fixed 5000ms sleep)
- Adds `installPlainTextWriteWatcher()` to both the helper and bootstrap heredocs, reusing the existing stream-json watcher slot and exitCode gate design (per Opus second-opinion after 3 consecutive G1 No-Go rounds)
- Adds regression tests: no-output-success fixture (helper + bootstrap), and a byte-for-byte parity test between the helper/bootstrap copies of `installPlainTextWriteWatcher`

## Review status
- G1: Go (4th submission)
- G2: Go (Blocker-free; non-blocker follow-up tests included in this PR)
- G3: Go (Blocker-free)
- Real-device smoke test (this session): helper branch and bootstrap branch both correctly wait past the old 5s timeout and print output with exit 0 (8s and 11s respectively)

## Test plan
- [x] `node --test packages/claude-code/lib/termux-run-claude-native.test.js` — 66 pass / 0 fail / 1 skip
- [x] tgz install + real native binary (2.1.231) smoke test, helper branch
- [x] tgz install + real native binary (2.1.231) smoke test, bootstrap branch
- [ ] G4 verification review (pending)