### PR TITLE
test: remove flaky wall-clock threshold in bootstrap async-exit test

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.test.js
+++ b/packages/claude-code/lib/termux-run-claude-native.test.js
@@ -820,9 +820,6 @@ test('bootstrap branch (-p + CLAUDE_TERMUX_STDIN=inherit): normal/sync-exit/asyn
     try {
       assert.ok((r.stdout || '').includes('ok'), `scenario=${scenario} stdout=${r.stdout} stderr=${r.stderr}`);
       assert.equal(r.status, 0, `scenario=${scenario} status=${r.status} stderr=${r.stderr}`);
-      if (scenario === 'async-exit') {
-        assert.ok(r.elapsedMs >= 250, `expected wait >= 250ms, got ${r.elapsedMs}ms`);
-      }
     } finally {
       fs.rmSync(r.tmpBase, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Removes the environment-dependent `elapsed >= 250ms` assertion from the bootstrap async-exit test that was causing failures on GitHub Actions runners.

- **Symptom:** `expected wait >= 250ms, got 141ms` failures on GitHub Actions (reproduced consistently in 2 consecutive runs)
- **Root cause:** `installPlainTextWriteWatcher` exits immediately upon detecting the 'ok' output write, rather than waiting a fixed duration. On fast runners, the elapsed time (~100ms process overhead + 100ms `setTimeout`) falls below the 250ms threshold despite correct behavior
- **Fix:** Removed the wall-clock threshold check and retained the environment-independent `stdout.includes('ok')` verification, which is a more reliable indicator that the wrapper correctly waited for delayed output and exited appropriately
- **Review:** G1 (design) and G2 (implementation plan) reviews completed and approved by GPT-5.6-terra

## Testing

The test fixture continues to verify:
1. Output is produced in all scenarios (normal/sync-exit/async-exit)  
2. Exit status is 0
3. No change to the test count — only the flaky assertion is removed; the test case itself remains