### PR TITLE
Track claude-code 2.1.233 candidate

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -698,6 +698,15 @@
       "tarball_integrity": "sha512-5Aub8i5pjCVlDBP/tIpHwO/8owfNBu2+FP+w0U8Jmy9s6cEhg/HB7Nyp9KyADhN74w6t0TVGvzUdnFXVMANI4Q==",
       "tarball_sha256": "97322189ff3c884e86d2ba2981d21c9874ca78261a8bff65a4ef6f673ef98fa6",
       "status": "termux_verified"
+    },
+    "2.1.233": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.233",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.233",
+      "entry_js_offset": 285594321,
+      "entry_end_offset": 312183763,
+      "tarball_integrity": "sha512-G7Te22sph7qywNyfIcQq7Li7bbQp8zBHZV4mDBBP5ZXswkGDJSip8MSNU2OlHsoVgcLtTzNlm0U25wys/r0jag==",
+      "tarball_sha256": "fb28c7df8f9c2aef8b7ed54aff84714caf0c47cfe245d93ceb5425b2c209de47",
+      "status": "offset_discovered"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.232",
-  "latest_candidate_version": "2.1.232",
+  "latest_candidate_version": "2.1.233",
   "previous_stable_version": "2.1.231",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -698,6 +698,15 @@
       "tarball_integrity": "sha512-5Aub8i5pjCVlDBP/tIpHwO/8owfNBu2+FP+w0U8Jmy9s6cEhg/HB7Nyp9KyADhN74w6t0TVGvzUdnFXVMANI4Q==",
       "tarball_sha256": "97322189ff3c884e86d2ba2981d21c9874ca78261a8bff65a4ef6f673ef98fa6",
       "status": "termux_verified"
+    },
+    "2.1.233": {
+      "wrapper_spec": "@anthropic-ai/claude-code@2.1.233",
+      "native_spec": "@anthropic-ai/claude-code-linux-arm64@2.1.233",
+      "entry_js_offset": 285594321,
+      "entry_end_offset": 312183763,
+      "tarball_integrity": "sha512-G7Te22sph7qywNyfIcQq7Li7bbQp8zBHZV4mDBBP5ZXswkGDJSip8MSNU2OlHsoVgcLtTzNlm0U25wys/r0jag==",
+      "tarball_sha256": "fb28c7df8f9c2aef8b7ed54aff84714caf0c47cfe245d93ceb5425b2c209de47",
+      "status": "offset_discovered"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
   "latest_audited_version": "2.1.232",
-  "latest_candidate_version": "2.1.232",
+  "latest_candidate_version": "2.1.233",
   "previous_stable_version": "2.1.231",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.232",
+  "version": "2.1.233",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "GPL-3.0-only",
   "bin": {


### PR DESCRIPTION
Automated upstream claude-code intake.

- upstream: @anthropic-ai/claude-code@2.1.233
- status: offset_discovered
- Next: Device B verification -> promote-verified-version.js -> npm publish