### PR TITLE
chore: promote claude-code 2.1.233 to termux_verified status

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -706,7 +706,7 @@
       "entry_end_offset": 312183763,
       "tarball_integrity": "sha512-G7Te22sph7qywNyfIcQq7Li7bbQp8zBHZV4mDBBP5ZXswkGDJSip8MSNU2OlHsoVgcLtTzNlm0U25wys/r0jag==",
       "tarball_sha256": "fb28c7df8f9c2aef8b7ed54aff84714caf0c47cfe245d93ceb5425b2c209de47",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.232",
+  "latest_audited_version": "2.1.233",
   "latest_candidate_version": "2.1.233",
-  "previous_stable_version": "2.1.231",
+  "previous_stable_version": "2.1.232",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -706,7 +706,7 @@
       "entry_end_offset": 312183763,
       "tarball_integrity": "sha512-G7Te22sph7qywNyfIcQq7Li7bbQp8zBHZV4mDBBP5ZXswkGDJSip8MSNU2OlHsoVgcLtTzNlm0U25wys/r0jag==",
       "tarball_sha256": "fb28c7df8f9c2aef8b7ed54aff84714caf0c47cfe245d93ceb5425b2c209de47",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.232",
+  "latest_audited_version": "2.1.233",
   "latest_candidate_version": "2.1.233",
-  "previous_stable_version": "2.1.231",
+  "previous_stable_version": "2.1.232",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
- promote claude-code 2.1.233 from offset_discovered to termux_verified via scripts/promote-verified-version.js
- G4検証レビュー(GPT-5.6-terra)でGo判定取得済み(Blockerなし)。Bun property access count閾値は既存の`>=232→45`ラダーがそのまま適用可能とterraが確認済み(コード変更不要)。

## Test plan
- [x] node scripts/promote-verified-version.js 2.1.233 実行、差分確認
- [x] 実機スモークテスト済み(version/-p helper/-p bootstrap/update/TUI)