### PR TITLE
chore: promote claude-code 2.1.234 to termux_verified status

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -715,7 +715,7 @@
       "entry_end_offset": 315945779,
       "tarball_integrity": "sha512-+uKUA99AEcsdEoPpWqDq46jCuPLbmb+HgF67zZ7Et7vPzQpUZp+UAERVFz6QPxqib+wNUdRTpHrbVJNMqBaj/Q==",
       "tarball_sha256": "2a0510532bc08ea349f153a940530107b6301515161911f9045904f8c9d1fc46",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.233",
+  "latest_audited_version": "2.1.234",
   "latest_candidate_version": "2.1.234",
-  "previous_stable_version": "2.1.232",
+  "previous_stable_version": "2.1.233",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -715,7 +715,7 @@
       "entry_end_offset": 315945779,
       "tarball_integrity": "sha512-+uKUA99AEcsdEoPpWqDq46jCuPLbmb+HgF67zZ7Et7vPzQpUZp+UAERVFz6QPxqib+wNUdRTpHrbVJNMqBaj/Q==",
       "tarball_sha256": "2a0510532bc08ea349f153a940530107b6301515161911f9045904f8c9d1fc46",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.233",
+  "latest_audited_version": "2.1.234",
   "latest_candidate_version": "2.1.234",
-  "previous_stable_version": "2.1.232",
+  "previous_stable_version": "2.1.233",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote 2.1.234 from offset_discovered to termux_verified status.

- Update claude-native-audited-versions.json (status change)
- Update claude-termux-release-manifest.json (latest_audited_version, previous_stable_version)