### PR TITLE
chore: promote claude-code 2.1.235 to termux_verified status

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -724,7 +724,7 @@
       "entry_end_offset": 318530584,
       "tarball_integrity": "sha512-IcG8gsVDgQQpsdPa47bZ0JKR1TzfKin5GdBXzwFLhFO5LIyQ6b/HelB7PRkO5BPiz4rplOHICU86PvIJ/gXVuQ==",
       "tarball_sha256": "2ff29f0ef4817bdcb10e4273bdeffa0b6f3d0033e431f557b4399fc36a18476f",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.234",
+  "latest_audited_version": "2.1.235",
   "latest_candidate_version": "2.1.235",
-  "previous_stable_version": "2.1.233",
+  "previous_stable_version": "2.1.234",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -724,7 +724,7 @@
       "entry_end_offset": 318530584,
       "tarball_integrity": "sha512-IcG8gsVDgQQpsdPa47bZ0JKR1TzfKin5GdBXzwFLhFO5LIyQ6b/HelB7PRkO5BPiz4rplOHICU86PvIJ/gXVuQ==",
       "tarball_sha256": "2ff29f0ef4817bdcb10e4273bdeffa0b6f3d0033e431f557b4399fc36a18476f",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.234",
+  "latest_audited_version": "2.1.235",
   "latest_candidate_version": "2.1.235",
-  "previous_stable_version": "2.1.233",
+  "previous_stable_version": "2.1.234",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Device A (tgz smoke test) and Device B (npm candidate install) both confirmed OK by the user. TUI check also confirmed OK.