### PR TITLE
fix: add typeof Bun count threshold for claude-code 2.1.237

### DIFF
--- a/packages/claude-code/lib/termux-run-claude-native.sh
+++ b/packages/claude-code/lib/termux-run-claude-native.sh
@@ -572,6 +572,7 @@ function rewriteNativeChunkSource(source) {
   const _typeofBunExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 237)) return 8;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 200)) return 7;
     return 6;
   })();
@@ -1528,6 +1529,7 @@ function rewriteNativeChunkSource(source) {
   const _typeofBunExpected = (() => {
     const _ver = String(process.env.CURRENT_CLAUDE_VERSION || '');
     const _m = _ver.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 237)) return 8;
     if (_m && (Number(_m[1]) > 2 || Number(_m[2]) > 1 || Number(_m[3]) >= 200)) return 7;
     return 6;
   })();


### PR DESCRIPTION
## Summary
- `typeof Bun`カウント閾値ラダーに新しい段を追加（>=237で値8を返す）
- 2箇所（helper/bootstrap分岐）を同じ内容で修正
- Bun property accessカウントは変更なし（G1/G2レビュー確認済み）

## Testing
- 既存テスト: 63 PASS
- stream-json関連の既知失敗: 5件（修正内容と無関係）

G1/G2(GPT-5.6-terra)でレビュー済み、Bun property accessは変更不要と確認済み

🤖 Generated with Claude Code