### PR TITLE
chore: promote claude-code 2.1.237 to termux_verified status

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -733,7 +733,7 @@
       "entry_end_offset": 322298246,
       "tarball_integrity": "sha512-+m44UaA9YMj+LvZUF5WWNQoz2rcNxlFbpbJPNWFvQRyBWEINGMddDiJEHqW0YuJWDwlrYWq4KlCRBB2UnaTRaw==",
       "tarball_sha256": "6d4e8bad1f1792a950fc03ce2dd5133e99f79645e61e526b4abbaa168daca2c0",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.235",
+  "latest_audited_version": "2.1.237",
   "latest_candidate_version": "2.1.237",
-  "previous_stable_version": "2.1.234",
+  "previous_stable_version": "2.1.235",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -733,7 +733,7 @@
       "entry_end_offset": 322298246,
       "tarball_integrity": "sha512-+m44UaA9YMj+LvZUF5WWNQoz2rcNxlFbpbJPNWFvQRyBWEINGMddDiJEHqW0YuJWDwlrYWq4KlCRBB2UnaTRaw==",
       "tarball_sha256": "6d4e8bad1f1792a950fc03ce2dd5133e99f79645e61e526b4abbaa168daca2c0",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.235",
+  "latest_audited_version": "2.1.237",
   "latest_candidate_version": "2.1.237",
-  "previous_stable_version": "2.1.234",
+  "previous_stable_version": "2.1.235",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Device A (tgz smoke test) and Device B (npm candidate install) both confirmed OK by the user. TUI check also confirmed OK.