### PR TITLE
chore: promote claude-code 2.1.238 to termux_verified status

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -742,7 +742,7 @@
       "entry_end_offset": 326443583,
       "tarball_integrity": "sha512-V948Ylqj6a2hCjCRIt/cd6P1z0Zw/jikThzK3kdEWvF4pwS45IhJAkCoZHN3XUTp+LKmCmU7077B3auexHbVVg==",
       "tarball_sha256": "5e25fce4762c0b6490646e78ee78a221c6302de1674874df03e689becf6c14b4",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.237",
+  "latest_audited_version": "2.1.238",
   "latest_candidate_version": "2.1.238",
-  "previous_stable_version": "2.1.235",
+  "previous_stable_version": "2.1.237",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -742,7 +742,7 @@
       "entry_end_offset": 326443583,
       "tarball_integrity": "sha512-V948Ylqj6a2hCjCRIt/cd6P1z0Zw/jikThzK3kdEWvF4pwS45IhJAkCoZHN3XUTp+LKmCmU7077B3auexHbVVg==",
       "tarball_sha256": "5e25fce4762c0b6490646e78ee78a221c6302de1674874df03e689becf6c14b4",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.237",
+  "latest_audited_version": "2.1.238",
   "latest_candidate_version": "2.1.238",
-  "previous_stable_version": "2.1.235",
+  "previous_stable_version": "2.1.237",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
$## Summary\n- Promote Claude Code 2.1.238 from `offset_discovered` to `termux_verified`.\n- Update the release manifest to set `latest_audited_version` to `2.1.238`.\n\n## Verification\n- Candidate intake PR #319 is merged (`1ba92bc`).\n- Candidate publish completed; npm実測で `candidate: "2.1.238"` を確認済み。\n- Device A / Device B の実機検証はユーザー確認済み。\n\n## Scope\n- npm publishは含まない。\n- G3コーディングレビュー前のため、このPRではマージしない。