### PR TITLE
harden: sanitize child_process call in prepare-native.js...

### DIFF
--- a/packages/claude-code/lib/prepare-native.js
+++ b/packages/claude-code/lib/prepare-native.js
@@ -76,6 +76,9 @@ function fetchNativeTarball(spec, packDir) {
     if (!tarballUrl) {
       throw new Error(`npm view did not return dist.tarball for ${spec}`);
     }
+    if (!/^https:\/\//.test(tarballUrl)) {
+      throw new Error(`Unexpected tarball URL scheme for ${spec}`);
+    }
     run('curl', [
       '--fail',
       '--location',
@@ -83,6 +86,7 @@ function fetchNativeTarball(spec, packDir) {
       '--connect-timeout', String(curlConnectTimeout),
       '--max-time', String(curlMaxTime),
       '--output', directTarball,
+      '--',
       tarballUrl,
     ]);
     if (fs.existsSync(directTarball)) {


### PR DESCRIPTION
## Summary
Harden input handling in `packages/claude-code/lib/prepare-native.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `packages/claude-code/lib/prepare-native.js:54` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `command`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Changes
- `packages/claude-code/lib/prepare-native.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
