### PR TITLE
chore: promote claude-code 2.1.239 to termux_verified status

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -751,7 +751,7 @@
       "entry_end_offset": 330145099,
       "tarball_integrity": "sha512-ZEssQZvMi0QNGppgW5fl+o83c1eCBjmsqVG/w4tZIp897LycumN2VkQDSVDZRH9gUyOWJFPtQo6ztdxO2G/Ntg==",
       "tarball_sha256": "9a4edf851888e0bb8225ace798ef60aef0c8f6f2061abdcc0385e9ad5f61f16a",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.238",
+  "latest_audited_version": "2.1.239",
   "latest_candidate_version": "2.1.239",
-  "previous_stable_version": "2.1.237",
+  "previous_stable_version": "2.1.238",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -751,7 +751,7 @@
       "entry_end_offset": 330145099,
       "tarball_integrity": "sha512-ZEssQZvMi0QNGppgW5fl+o83c1eCBjmsqVG/w4tZIp897LycumN2VkQDSVDZRH9gUyOWJFPtQo6ztdxO2G/Ntg==",
       "tarball_sha256": "9a4edf851888e0bb8225ace798ef60aef0c8f6f2061abdcc0385e9ad5f61f16a",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.238",
+  "latest_audited_version": "2.1.239",
   "latest_candidate_version": "2.1.239",
-  "previous_stable_version": "2.1.237",
+  "previous_stable_version": "2.1.238",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promotes 2.1.239 to termux_verified after G4 device/TUI verification. Generated via scripts/promote-verified-version.js 2.1.239 (updates status + release manifest together, per G4 review requirement).