### PR TITLE
chore: temporarily revert package.json version to 2.1.239 for release-finalize

### DIFF
--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.240",
+  "version": "2.1.239",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "GPL-3.0-only",
   "bin": {


### PR DESCRIPTION
Temporary fix to unblock release-finalize.yml for 2.1.239, which requires packages/claude-code/package.json version to match config/claude-termux-release-manifest.json latest_audited_version (2.1.239). This will be reverted back to 2.1.240 in a follow-up PR after release-finalize completes.