### PR TITLE
chore: restore package.json version to 2.1.240 (candidate) after 2.1.239 release-finalize

### DIFF
--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bash0816/claude-code",
-  "version": "2.1.239",
+  "version": "2.1.240",
   "description": "Unofficial Termux-native Claude Code wrapper with audited native replay",
   "license": "GPL-3.0-only",
   "bin": {


### PR DESCRIPTION
Follow-up to PR #328. The temporary version revert for 2.1.239 release-finalize is complete (GitHub Release v2.1.239 published). Restoring package.json to the current candidate version 2.1.240.