### PR TITLE
chore: promote claude-code 2.1.240 to termux_verified status

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -760,7 +760,7 @@
       "entry_end_offset": 330221534,
       "tarball_integrity": "sha512-pzI3/EiPTkORSy4YcKy9r7ICrl5KjDZJLvIh8H6dIWR4KFzXZ0CPZakRqtWNr79HzJCczAz1DiSzbipbqHvMUg==",
       "tarball_sha256": "e4d5f0c8ca3748c7469fb7e1da9eba4e0a65926f12859bfd478e099d6b3cac75",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.239",
+  "latest_audited_version": "2.1.240",
   "latest_candidate_version": "2.1.240",
-  "previous_stable_version": "2.1.238",
+  "previous_stable_version": "2.1.239",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -760,7 +760,7 @@
       "entry_end_offset": 330221534,
       "tarball_integrity": "sha512-pzI3/EiPTkORSy4YcKy9r7ICrl5KjDZJLvIh8H6dIWR4KFzXZ0CPZakRqtWNr79HzJCczAz1DiSzbipbqHvMUg==",
       "tarball_sha256": "e4d5f0c8ca3748c7469fb7e1da9eba4e0a65926f12859bfd478e099d6b3cac75",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.239",
+  "latest_audited_version": "2.1.240",
   "latest_candidate_version": "2.1.240",
-  "previous_stable_version": "2.1.238",
+  "previous_stable_version": "2.1.239",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promotes 2.1.240 to termux_verified after G4 device/TUI verification. Generated via scripts/promote-verified-version.js 2.1.240 (updates status + release manifest together, per G4 review requirement).