### PR TITLE
Promote claude-code 2.1.245 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.241
+npm install -g @bash0816/claude-code@2.1.245
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.241` | ✅ **Recommended / 推奨** — latest |
-| `2.1.240` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.245` | ✅ **Recommended / 推奨** — latest |
+| `2.1.241` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.220-2` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -149,7 +149,7 @@ Example:
 例:
 
 ```text
-2.1.241 (Claude Code)
+2.1.245 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -777,7 +777,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-Qbn5HnZbYeW4GdifVkDGfcVKqj3/f3U9sfVd3LEaUZh08CcS8D/ptJ76zuBfQUGHJHfToAdNVfak86uJ84b1Dg==",
       "tarball_sha256": "668662e7b5d91a93cff6c75736e60f3d5d3bed4cbe077ae4feefc63ad1253f4d",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.241",
+  "latest_audited_version": "2.1.245",
   "latest_candidate_version": "2.1.245",
-  "previous_stable_version": "2.1.240",
+  "previous_stable_version": "2.1.241",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.241
+npm install -g @bash0816/claude-code@2.1.245
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -777,7 +777,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-Qbn5HnZbYeW4GdifVkDGfcVKqj3/f3U9sfVd3LEaUZh08CcS8D/ptJ76zuBfQUGHJHfToAdNVfak86uJ84b1Dg==",
       "tarball_sha256": "668662e7b5d91a93cff6c75736e60f3d5d3bed4cbe077ae4feefc63ad1253f4d",
-      "status": "offset_discovered"
+      "status": "termux_verified"
     }
   }
 }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.241",
+  "latest_audited_version": "2.1.245",
   "latest_candidate_version": "2.1.245",
-  "previous_stable_version": "2.1.240",
+  "previous_stable_version": "2.1.241",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
Promote claude-code 2.1.245 from `offset_discovered` to `termux_verified` status.

## Context
- Version 2.1.245 was merged in PR #336 with esm-chunked native format support
- candidate publish completed (npm dist-tag `candidate: 2.1.245`)
- Device A/B TUI and CLI smoke tests passed

## Changes
- Updated `status` to `termux_verified` in both audited versions files
- Updated `latest_audited_version` to 2.1.245 in manifest files
- Updated `previous_stable_version` to 2.1.241

## Testing
- Device A: TUI verification passed
- Device B: CLI smoke test and `-p` interactive mode passed