### PR TITLE
chore: add acorn dependency for cycle_hoists audit tooling

### DIFF
--- a/.github/workflows/claude-code-version-watch.yml
+++ b/.github/workflows/claude-code-version-watch.yml
@@ -68,6 +68,9 @@ jobs:
             echo "New version to intake: $latest"
           fi
 
+      - name: Install scripts dependencies
+        run: npm ci --prefix scripts
+
       - name: Discover offsets and integrity
         if: steps.mode.outputs.mode == 'new_intake'
         run: |

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -71,6 +71,10 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install scripts dependencies
+        working-directory: .
+        run: npm ci --prefix scripts
+
       - name: Syntax check
         run: |
           set -euo pipefail

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.tgz
 /.verify-*/
+/scripts/node_modules/

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -24,6 +24,8 @@
 
 新しいupstream版（`X.Y.Z`）の offset と tarball hash を調査し、両方の config に追加する。
 
+> ⚠️ **事前準備**: 以下のスクリプト実行の前に、`npm ci --prefix scripts` で監査スクリプトの依存関係(acorn など)をインストールしておく必要があります。
+
 ```
 config/claude-native-audited-versions.json
 packages/claude-code/config/claude-native-audited-versions.json

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,38 @@
+{
+  "name": "claude-code-termux-scripts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-code-termux-scripts",
+      "dependencies": {
+        "acorn": "8.15.0",
+        "acorn-walk": "8.3.4"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "claude-code-termux-scripts",
+  "private": true,
+  "description": "Maintainer-only tooling for tracking upstream @anthropic-ai/claude-code releases. Not published to npm; not part of the packages/claude-code distribution.",
+  "dependencies": {
+    "acorn": "8.15.0",
+    "acorn-walk": "8.3.4"
+  }
+}


### PR DESCRIPTION
メンテナ専用のscripts/配下でのみ使う依存追加。npm公開物(packages/claude-code)には一切影響しない。後続の循環参照検出ロジック実装の前提となるインフラPR。