### PR TITLE
Promote claude-code 2.1.248 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.245
+npm install -g @bash0816/claude-code@2.1.248
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.245` | ✅ **Recommended / 推奨** — latest |
-| `2.1.241` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.248` | ✅ **Recommended / 推奨** — latest |
+| `2.1.245` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.220-2` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -149,7 +149,7 @@ Example:
 例:
 
 ```text
-2.1.245 (Claude Code)
+2.1.248 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Only versions registered in the audited metadata can run.
 **日本語:** バージョン 2.1.206-1 (候補版) では、Termux 版の `/model` コマンドで Fable 5 モデル選択肢が表示されない不具合を修正しました。原因は起動時に `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` が強制 export されており、upstream の Bootstrap 処理（モデル取得）が抑制されていました。
 
 <!-- UPSTREAM_VERSION_START -->
-Official upstream (`@anthropic-ai/claude-code`): latest `2.1.248` / stable `2.1.231`
-This repo's published latest audited release: `2.1.245`
+Official upstream (`@anthropic-ai/claude-code`): latest `2.1.251` / stable `2.1.236`
+This repo's published latest audited release: `2.1.248`
 
-公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.248` / stable `2.1.231`
-この repo の公開 latest audited release: `2.1.245`
+公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.251` / stable `2.1.236`
+この repo の公開 latest audited release: `2.1.248`
 <!-- UPSTREAM_VERSION_END -->
 
 For the full version history, see [RELEASES.md](RELEASES.md).

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -786,19 +786,78 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-2qwjgGuzlVfkJC7UWUjl86hiv5Ok5vtVxAZ/5fpdhzQKuBLlxrJJu3z5tVI+VrO/x/hcqx5kJuy9/O9K4eT+Kg==",
       "tarball_sha256": "bd2e2b6ebace34039b073b0f586d521ec09c895fa2a39de8d1c86423ae5884ca",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1946,
       "byte_count": 136124175,
       "cycle_hoists": [
-        { "file": "chunk-vmw9kxhv.js", "targetModule": "chunk-y0jj307t.js", "expectedOccurrences": 1, "assertProperties": [] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-ppd18hq1.js", "expectedOccurrences": 1, "assertProperties": ["MonitorTool"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-830s9480.js", "expectedOccurrences": 1, "assertProperties": ["EndConversationTool"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-m4hx5z9g.js", "expectedOccurrences": 1, "assertProperties": ["ArtifactTool"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-eg121wbt.js", "expectedOccurrences": 1, "assertProperties": ["WorkflowTool"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-prrm838s.js", "expectedOccurrences": 1, "assertProperties": [] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-exvwsc2a.js", "expectedOccurrences": 2, "assertProperties": [] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-s61yn21a.js", "expectedOccurrences": 1, "assertProperties": ["default"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-040m9a9s.js", "expectedOccurrences": 3, "assertProperties": ["getWorkflowCommands", "invalidateWorkflowCache", "warmWorkflows"] }
+        {
+          "file": "chunk-vmw9kxhv.js",
+          "targetModule": "chunk-y0jj307t.js",
+          "expectedOccurrences": 1,
+          "assertProperties": []
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-ppd18hq1.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "MonitorTool"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-830s9480.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "EndConversationTool"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-m4hx5z9g.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "ArtifactTool"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-eg121wbt.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "WorkflowTool"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-prrm838s.js",
+          "expectedOccurrences": 1,
+          "assertProperties": []
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-exvwsc2a.js",
+          "expectedOccurrences": 2,
+          "assertProperties": []
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-s61yn21a.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "default"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-040m9a9s.js",
+          "expectedOccurrences": 3,
+          "assertProperties": [
+            "getWorkflowCommands",
+            "invalidateWorkflowCache",
+            "warmWorkflows"
+          ]
+        }
       ]
     }
   }

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.245",
+  "latest_audited_version": "2.1.248",
   "latest_candidate_version": "2.1.248",
-  "previous_stable_version": "2.1.241",
+  "previous_stable_version": "2.1.245",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -116,6 +116,7 @@ npm install -g @bash0816/claude-code@candidate
 node scripts/promote-verified-version.js X.Y.Z-N
 node scripts/update-release-manifest.js
 node scripts/update-readme-version-guidance.js
+node scripts/update-readme-from-doctor.js
 ```
 
 これで:
@@ -124,6 +125,7 @@ node scripts/update-readme-version-guidance.js
 - `latest_candidate_version` も `X.Y.Z-N`（同一）
 - `previous_stable_version` が前の stable に更新される
 - README の Supported Versions テーブル・バージョン参照が更新される
+- README の UPSTREAM_VERSION ブロック（upstream latest/stable・この repo の公開 latest audited）が更新される
 
 ### 3-2. コミット・push（自動化トリガー）
 

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.245
+npm install -g @bash0816/claude-code@2.1.248
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -786,19 +786,78 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-2qwjgGuzlVfkJC7UWUjl86hiv5Ok5vtVxAZ/5fpdhzQKuBLlxrJJu3z5tVI+VrO/x/hcqx5kJuy9/O9K4eT+Kg==",
       "tarball_sha256": "bd2e2b6ebace34039b073b0f586d521ec09c895fa2a39de8d1c86423ae5884ca",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1946,
       "byte_count": 136124175,
       "cycle_hoists": [
-        { "file": "chunk-vmw9kxhv.js", "targetModule": "chunk-y0jj307t.js", "expectedOccurrences": 1, "assertProperties": [] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-ppd18hq1.js", "expectedOccurrences": 1, "assertProperties": ["MonitorTool"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-830s9480.js", "expectedOccurrences": 1, "assertProperties": ["EndConversationTool"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-m4hx5z9g.js", "expectedOccurrences": 1, "assertProperties": ["ArtifactTool"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-eg121wbt.js", "expectedOccurrences": 1, "assertProperties": ["WorkflowTool"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-prrm838s.js", "expectedOccurrences": 1, "assertProperties": [] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-exvwsc2a.js", "expectedOccurrences": 2, "assertProperties": [] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-s61yn21a.js", "expectedOccurrences": 1, "assertProperties": ["default"] },
-        { "file": "chunk-9n7t2tbt.js", "targetModule": "chunk-040m9a9s.js", "expectedOccurrences": 3, "assertProperties": ["getWorkflowCommands", "invalidateWorkflowCache", "warmWorkflows"] }
+        {
+          "file": "chunk-vmw9kxhv.js",
+          "targetModule": "chunk-y0jj307t.js",
+          "expectedOccurrences": 1,
+          "assertProperties": []
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-ppd18hq1.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "MonitorTool"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-830s9480.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "EndConversationTool"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-m4hx5z9g.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "ArtifactTool"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-eg121wbt.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "WorkflowTool"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-prrm838s.js",
+          "expectedOccurrences": 1,
+          "assertProperties": []
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-exvwsc2a.js",
+          "expectedOccurrences": 2,
+          "assertProperties": []
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-s61yn21a.js",
+          "expectedOccurrences": 1,
+          "assertProperties": [
+            "default"
+          ]
+        },
+        {
+          "file": "chunk-9n7t2tbt.js",
+          "targetModule": "chunk-040m9a9s.js",
+          "expectedOccurrences": 3,
+          "assertProperties": [
+            "getWorkflowCommands",
+            "invalidateWorkflowCache",
+            "warmWorkflows"
+          ]
+        }
       ]
     }
   }

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.245",
+  "latest_audited_version": "2.1.248",
   "latest_candidate_version": "2.1.248",
-  "previous_stable_version": "2.1.241",
+  "previous_stable_version": "2.1.245",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/scripts/update-readme-version-guidance.js
+++ b/scripts/update-readme-version-guidance.js
@@ -116,16 +116,6 @@ function updateRootReadme(content, versions, latestAudited, previousStable, stab
   // Supported Versions table (between comment markers)
   content = updateSupportedVersionsTable(content, latestAudited, previousStable, stablePinned);
 
-  // Text references to latest audited version
-  content = content.replace(
-    /This repo's published latest audited\nrelease is `[^`]+`\./,
-    `This repo's published latest audited\nrelease is \`${latestAudited}\`.`
-  );
-  content = content.replace(
-    /この repo の公開 latest audited release は `[^`]+` です。/,
-    `この repo の公開 latest audited release は \`${latestAudited}\` です。`
-  );
-
   // Expected output example
   const expectedBlock = [
     formatTextBlock(['<installed_audited_version> (Claude Code)']),


### PR DESCRIPTION
## 概要

claude-code 2.1.248 を termux_verified ステータスに昇格します。

## 前提条件

- ✅ 2.1.248 は既に npm の candidate dist-tag に publish 済み
- ✅ Device A/B 実機検証完了

## 変更内容

- `config/claude-native-audited-versions.json`: 2.1.248 のステータスを `offset_discovered` → `termux_verified` に昇格
- `config/claude-termux-release-manifest.json`: `latest_audited_version` を 2.1.248 に、`previous_stable_version` を 2.1.245 に更新
- `README.md`: サポートバージョン表を更新、インストール例を 2.1.248 に変更
- JSON フォーマットの改善

## マージ後の自動処理

このブランチを main にマージすると、GitHub Actions の `promote-and-publish.yml` が自動発火し、npm の latest dist-tag を 2.1.248 に更新します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)