### PR TITLE
release: promote claude-code 2.1.251 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.248
+npm install -g @bash0816/claude-code@2.1.251
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.248` | ✅ **Recommended / 推奨** — latest |
-| `2.1.245` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.251` | ✅ **Recommended / 推奨** — latest |
+| `2.1.248` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.220-2` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -97,10 +97,10 @@ Only versions registered in the audited metadata can run.
 
 <!-- UPSTREAM_VERSION_START -->
 Official upstream (`@anthropic-ai/claude-code`): latest `2.1.251` / stable `2.1.236`
-This repo's published latest audited release: `2.1.248`
+This repo's published latest audited release: `2.1.251`
 
 公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.251` / stable `2.1.236`
-この repo の公開 latest audited release: `2.1.248`
+この repo の公開 latest audited release: `2.1.251`
 <!-- UPSTREAM_VERSION_END -->
 
 For the full version history, see [RELEASES.md](RELEASES.md).
@@ -161,7 +161,7 @@ Example:
 例:
 
 ```text
-2.1.248 (Claude Code)
+2.1.251 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -866,7 +866,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-h4EXRyV25yJfez40cTIoBlJptJqccP8nIDPdDMO9TDPUzZ6e5Y3OO9AgrfdMRAgccaTRsKfJenh7lA2D40nzdw==",
       "tarball_sha256": "50760f283bf289a8bfb6f25ab86276808fd038b8f724ba5eaffb9b195483846d",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1971,
       "byte_count": 126850982,
       "cycle_hoists": [

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.248",
+  "latest_audited_version": "2.1.251",
   "latest_candidate_version": "2.1.251",
-  "previous_stable_version": "2.1.245",
+  "previous_stable_version": "2.1.248",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.248
+npm install -g @bash0816/claude-code@2.1.251
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -866,7 +866,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-h4EXRyV25yJfez40cTIoBlJptJqccP8nIDPdDMO9TDPUzZ6e5Y3OO9AgrfdMRAgccaTRsKfJenh7lA2D40nzdw==",
       "tarball_sha256": "50760f283bf289a8bfb6f25ab86276808fd038b8f724ba5eaffb9b195483846d",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1971,
       "byte_count": 126850982,
       "cycle_hoists": [

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.248",
+  "latest_audited_version": "2.1.251",
   "latest_candidate_version": "2.1.251",
-  "previous_stable_version": "2.1.245",
+  "previous_stable_version": "2.1.248",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
## Summary
- Promote claude-code 2.1.251 to termux_verified status
- Update release manifest (latest_audited: 2.1.248 → 2.1.251, previous_stable: 2.1.245 → 2.1.248)
- Refresh README upstream version guidance block

Device A/B verification completed by user. G4 (fs-bunfs -p crash fix) Go obtained separately.