### PR TITLE
release: promote claude-code 2.1.252 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.251
+npm install -g @bash0816/claude-code@2.1.252
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.251` | ✅ **Recommended / 推奨** — latest |
-| `2.1.248` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.252` | ✅ **Recommended / 推奨** — latest |
+| `2.1.251` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.220-2` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -96,11 +96,11 @@ Only versions registered in the audited metadata can run.
 **日本語:** バージョン 2.1.206-1 (候補版) では、Termux 版の `/model` コマンドで Fable 5 モデル選択肢が表示されない不具合を修正しました。原因は起動時に `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` が強制 export されており、upstream の Bootstrap 処理（モデル取得）が抑制されていました。
 
 <!-- UPSTREAM_VERSION_START -->
-Official upstream (`@anthropic-ai/claude-code`): latest `2.1.251` / stable `2.1.236`
-This repo's published latest audited release: `2.1.251`
+Official upstream (`@anthropic-ai/claude-code`): latest `2.1.252` / stable `2.1.236`
+This repo's published latest audited release: `2.1.252`
 
-公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.251` / stable `2.1.236`
-この repo の公開 latest audited release: `2.1.251`
+公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.252` / stable `2.1.236`
+この repo の公開 latest audited release: `2.1.252`
 <!-- UPSTREAM_VERSION_END -->
 
 For the full version history, see [RELEASES.md](RELEASES.md).
@@ -161,7 +161,7 @@ Example:
 例:
 
 ```text
-2.1.251 (Claude Code)
+2.1.252 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -951,7 +951,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-y8lYCVmU9zWxCJu++dR00pZKykogS7rXFiJ/b++zyNSjnkmxZNGhhU/y+QFKzKUSMD2Ti/8DI3A+MW/ZVLQkMQ==",
       "tarball_sha256": "18894618abe7b569e9db97979c90181320e8e9a768f90729d2e9b955fd4ebde9",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1971,
       "byte_count": 126897278,
       "cycle_hoists": [

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.251",
+  "latest_audited_version": "2.1.252",
   "latest_candidate_version": "2.1.252",
-  "previous_stable_version": "2.1.248",
+  "previous_stable_version": "2.1.251",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.251
+npm install -g @bash0816/claude-code@2.1.252
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -951,7 +951,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-y8lYCVmU9zWxCJu++dR00pZKykogS7rXFiJ/b++zyNSjnkmxZNGhhU/y+QFKzKUSMD2Ti/8DI3A+MW/ZVLQkMQ==",
       "tarball_sha256": "18894618abe7b569e9db97979c90181320e8e9a768f90729d2e9b955fd4ebde9",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1971,
       "byte_count": 126897278,
       "cycle_hoists": [

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.251",
+  "latest_audited_version": "2.1.252",
   "latest_candidate_version": "2.1.252",
-  "previous_stable_version": "2.1.248",
+  "previous_stable_version": "2.1.251",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote 2.1.252 to termux_verified status following the same procedure as 2.1.251.