### PR TITLE
release: promote claude-code 2.1.258 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -1129,7 +1129,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-cbzsJZ4gMDp30eOlhA6qM+s0plv0TTKLhWX/y4CwNRspSQI8wPO5T1UafhimU4fTeznpPxH38m3k3vYkA9ypHw==",
       "tarball_sha256": "2f0ad50cd3efd5707323f48b43af22c5cbc045e74cdfc16d25c5a73581f3b196",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1802,
       "byte_count": 127808908,
       "cycle_hoists": [

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.257",
+  "latest_audited_version": "2.1.258",
   "latest_candidate_version": "2.1.258",
-  "previous_stable_version": "2.1.252",
+  "previous_stable_version": "2.1.257",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -1129,7 +1129,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-cbzsJZ4gMDp30eOlhA6qM+s0plv0TTKLhWX/y4CwNRspSQI8wPO5T1UafhimU4fTeznpPxH38m3k3vYkA9ypHw==",
       "tarball_sha256": "2f0ad50cd3efd5707323f48b43af22c5cbc045e74cdfc16d25c5a73581f3b196",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1802,
       "byte_count": 127808908,
       "cycle_hoists": [

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.257",
+  "latest_audited_version": "2.1.258",
   "latest_candidate_version": "2.1.258",
-  "previous_stable_version": "2.1.252",
+  "previous_stable_version": "2.1.257",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote 2.1.258 to termux_verified status following the same procedure as 2.1.257.