### PR TITLE
release: promote claude-code 2.1.259 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -1222,7 +1222,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-9NzlP79GXZcnaHmVbZO8pIPPafRTJzfSRAZeHbDyCAHnsMQWmkIbW2kOsDl1KpV93za+3Kdn6RuKIs+JRp0rag==",
       "tarball_sha256": "d14a6b349115c12765766d14b6d727a62bfcfb8da3ecd514348ce8788228e1ba",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1819,
       "byte_count": 129016569,
       "cycle_hoists": [

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.258",
+  "latest_audited_version": "2.1.259",
   "latest_candidate_version": "2.1.259",
-  "previous_stable_version": "2.1.257",
+  "previous_stable_version": "2.1.258",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -1222,7 +1222,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-9NzlP79GXZcnaHmVbZO8pIPPafRTJzfSRAZeHbDyCAHnsMQWmkIbW2kOsDl1KpV93za+3Kdn6RuKIs+JRp0rag==",
       "tarball_sha256": "d14a6b349115c12765766d14b6d727a62bfcfb8da3ecd514348ce8788228e1ba",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1819,
       "byte_count": 129016569,
       "cycle_hoists": [

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.258",
+  "latest_audited_version": "2.1.259",
   "latest_candidate_version": "2.1.259",
-  "previous_stable_version": "2.1.257",
+  "previous_stable_version": "2.1.258",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote claude-code 2.1.259 to termux_verified status.

Version 2.1.259 has passed all verification gates (G1-G4 ✓) and candidate publish, with successful device testing completed by the user.

- Updates latest_audited_version to 2.1.259
- Updates latest_candidate_version to 2.1.259 (no change)
- Updates previous_stable_version to 2.1.258

Related to: Release candidate 2.1.259