### PR TITLE
release: promote claude-code 2.1.260 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -1315,7 +1315,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-lOWJjMw3rRNBjQuGrFqErlk6FW4dbR1Nf51jFtUChv2auatQjPaooslxp9dG944XpNAvn++P65ife4hM2iww6w==",
       "tarball_sha256": "5860d42af37f83e5559543b46152d3e6c18364bc6b730d7b2bfb2093aa03353f",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1811,
       "byte_count": 126839894,
       "cycle_hoists": [

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.259",
+  "latest_audited_version": "2.1.260",
   "latest_candidate_version": "2.1.260",
-  "previous_stable_version": "2.1.258",
+  "previous_stable_version": "2.1.259",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -1315,7 +1315,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-lOWJjMw3rRNBjQuGrFqErlk6FW4dbR1Nf51jFtUChv2auatQjPaooslxp9dG944XpNAvn++P65ife4hM2iww6w==",
       "tarball_sha256": "5860d42af37f83e5559543b46152d3e6c18364bc6b730d7b2bfb2093aa03353f",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1811,
       "byte_count": 126839894,
       "cycle_hoists": [

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.259",
+  "latest_audited_version": "2.1.260",
   "latest_candidate_version": "2.1.260",
-  "previous_stable_version": "2.1.258",
+  "previous_stable_version": "2.1.259",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Device B実機検証完了。2.1.260をtermux_verifiedへ昇格します。

config/manifest ファイルが更新されています：
- latest_audited_version: 2.1.259 → 2.1.260
- previous_stable_version: 2.1.258 → 2.1.259