### PR TITLE
release: promote claude-code 2.1.261 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -1408,7 +1408,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-CfQNubIdasazT4vAduqx6wqWWUnUvwoVALXmPlZJ1LZFpv6iaZmdsTVB/dPniczEWDJ6kZZLsoEyDwhqbrKkwg==",
       "tarball_sha256": "12a0a7edd9a0c111ef500db3697a69efd05aefc868b74a12b78d9df0062377e6",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1818,
       "byte_count": 127796286,
       "cycle_hoists": [

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.260",
+  "latest_audited_version": "2.1.261",
   "latest_candidate_version": "2.1.261",
-  "previous_stable_version": "2.1.259",
+  "previous_stable_version": "2.1.260",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -1408,7 +1408,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-CfQNubIdasazT4vAduqx6wqWWUnUvwoVALXmPlZJ1LZFpv6iaZmdsTVB/dPniczEWDJ6kZZLsoEyDwhqbrKkwg==",
       "tarball_sha256": "12a0a7edd9a0c111ef500db3697a69efd05aefc868b74a12b78d9df0062377e6",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1818,
       "byte_count": 127796286,
       "cycle_hoists": [

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.260",
+  "latest_audited_version": "2.1.261",
   "latest_candidate_version": "2.1.261",
-  "previous_stable_version": "2.1.259",
+  "previous_stable_version": "2.1.260",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
昇格対象: 2.1.261 → termux_verified

Device B実機検証完了、昇格準備完了。