### PR TITLE
release: promote claude-code 2.1.263 to termux_verified

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -1501,7 +1501,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-RlJtLbl8xqFMf2zUdOKD4o5FkNhcgGjlS3Un8PNfSbv1fLQg3SqBQgEJhNEtSeKlEsOs26RnCG/jVk4yah8Udw==",
       "tarball_sha256": "64238be6b64968b17ce006fe15fb6e3a96b89ceeaa231fee4610cb34a521c44c",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1818,
       "byte_count": 127813378,
       "cycle_hoists": [

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.261",
+  "latest_audited_version": "2.1.263",
   "latest_candidate_version": "2.1.263",
-  "previous_stable_version": "2.1.260",
+  "previous_stable_version": "2.1.261",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -1501,7 +1501,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-RlJtLbl8xqFMf2zUdOKD4o5FkNhcgGjlS3Un8PNfSbv1fLQg3SqBQgEJhNEtSeKlEsOs26RnCG/jVk4yah8Udw==",
       "tarball_sha256": "64238be6b64968b17ce006fe15fb6e3a96b89ceeaa231fee4610cb34a521c44c",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1818,
       "byte_count": 127813378,
       "cycle_hoists": [

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.261",
+  "latest_audited_version": "2.1.263",
   "latest_candidate_version": "2.1.263",
-  "previous_stable_version": "2.1.260",
+  "previous_stable_version": "2.1.261",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Promote claude-code 2.1.263 to termux_verified status after Device B verification.