### PR TITLE
Promote 2.1.265 to termux_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Only versions registered in the audited metadata can run.
 **日本語:** バージョン 2.1.206-1 (候補版) では、Termux 版の `/model` コマンドで Fable 5 モデル選択肢が表示されない不具合を修正しました。原因は起動時に `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` が強制 export されており、upstream の Bootstrap 処理（モデル取得）が抑制されていました。
 
 <!-- UPSTREAM_VERSION_START -->
-Official upstream (`@anthropic-ai/claude-code`): latest `2.1.257` / stable `2.1.236`
-This repo's published latest audited release: `2.1.257`
+Official upstream (`@anthropic-ai/claude-code`): latest `2.1.267` / stable `2.1.236`
+This repo's published latest audited release: `2.1.265`
 
-公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.257` / stable `2.1.236`
-この repo の公開 latest audited release: `2.1.257`
+公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.267` / stable `2.1.236`
+この repo の公開 latest audited release: `2.1.265`
 <!-- UPSTREAM_VERSION_END -->
 
 For the full version history, see [RELEASES.md](RELEASES.md).

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ Only versions registered in the audited metadata can run.
 
 <!-- UPSTREAM_VERSION_START -->
 Official upstream (`@anthropic-ai/claude-code`): latest `2.1.267` / stable `2.1.236`
-This repo's published latest audited release: `2.1.265`
+This repo's latest audited release (release manifest): `2.1.265`
 
 公式 upstream (`@anthropic-ai/claude-code`): latest `2.1.267` / stable `2.1.236`
-この repo の公開 latest audited release: `2.1.265`
+この repo の latest audited release (release manifest 基準): `2.1.265`
 <!-- UPSTREAM_VERSION_END -->
 
 For the full version history, see [RELEASES.md](RELEASES.md).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Existing users on older installs should keep using `claude update` to migrate on
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.263
+npm install -g @bash0816/claude-code@2.1.265
 ```
 
 ## Update / 更新
@@ -84,8 +84,8 @@ Only versions registered in the audited metadata can run.
 <!-- SUPPORTED_VERSIONS_TABLE_START -->
 | Version | Status |
 |---------|--------|
-| `2.1.263` | ✅ **Recommended / 推奨** — latest |
-| `2.1.261` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.265` | ✅ **Recommended / 推奨** — latest |
+| `2.1.263` | ✅ rollback candidate — `@candidate` dist-tag |
 | `2.1.220-2` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 
@@ -161,7 +161,7 @@ Example:
 例:
 
 ```text
-2.1.263 (Claude Code)
+2.1.265 (Claude Code)
 ```
 
 ## Do Not Use / 非推奨

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Only versions registered in the audited metadata can run.
 | Version | Status |
 |---------|--------|
 | `2.1.265` | ✅ **Recommended / 推奨** — latest |
-| `2.1.263` | ✅ rollback candidate — `@candidate` dist-tag |
+| `2.1.263` | ✅ rollback version |
 | `2.1.220-2` | ✅ stable — `@stable` dist-tag |
 <!-- SUPPORTED_VERSIONS_TABLE_END -->
 

--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -1594,7 +1594,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-GXnUtObpOzFNdEKUuZbswfRzNtWteEvp4p/+0hW2gT0L/YEUw4hoKH+i6iJAHXzsT0mKw1PjzLWK2aUAlA1tAw==",
       "tarball_sha256": "e39f8c8374b27672cd916c4c17fa3bc88d13994e012c7c20320d831b6e44a5a5",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1827,
       "byte_count": 128265521,
       "cycle_hoists": [

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.263",
+  "latest_audited_version": "2.1.265",
   "latest_candidate_version": "2.1.265",
-  "previous_stable_version": "2.1.261",
+  "previous_stable_version": "2.1.263",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -125,7 +125,7 @@ node scripts/update-readme-from-doctor.js
 - `latest_candidate_version` も `X.Y.Z-N`（同一）
 - `previous_stable_version` が前の stable に更新される
 - README の Supported Versions テーブル・バージョン参照が更新される
-- README の UPSTREAM_VERSION ブロック（upstream latest/stable・この repo の公開 latest audited）が更新される
+- README の UPSTREAM_VERSION ブロック（upstream latest/stable・この repo の latest audited release (release manifest 基準)）が更新される
 
 ### 3-2. コミット・push（自動化トリガー）
 

--- a/packages/claude-code/README.md
+++ b/packages/claude-code/README.md
@@ -37,7 +37,7 @@ npm が `claude` bin link を管理する状態になれば、通常の `npm ins
 Latest audited version / 最新監査済み版:
 
 ```sh
-npm install -g @bash0816/claude-code@2.1.263
+npm install -g @bash0816/claude-code@2.1.265
 ```
 
 ## Update / 更新

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -1594,7 +1594,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-GXnUtObpOzFNdEKUuZbswfRzNtWteEvp4p/+0hW2gT0L/YEUw4hoKH+i6iJAHXzsT0mKw1PjzLWK2aUAlA1tAw==",
       "tarball_sha256": "e39f8c8374b27672cd916c4c17fa3bc88d13994e012c7c20320d831b6e44a5a5",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1827,
       "byte_count": 128265521,
       "cycle_hoists": [

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.263",
+  "latest_audited_version": "2.1.265",
   "latest_candidate_version": "2.1.265",
-  "previous_stable_version": "2.1.261",
+  "previous_stable_version": "2.1.263",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/scripts/update-readme-from-doctor.js
+++ b/scripts/update-readme-from-doctor.js
@@ -37,10 +37,10 @@ function buildSection(upstream, ourVersion) {
   const upstreamStable = upstream.stableVersion || '(unknown)';
   return `
 Official upstream (\`@anthropic-ai/claude-code\`): latest \`${upstreamLatest}\` / stable \`${upstreamStable}\`
-This repo's published latest audited release: \`${ourVersion}\`
+This repo's latest audited release (release manifest): \`${ourVersion}\`
 
 公式 upstream (\`@anthropic-ai/claude-code\`): latest \`${upstreamLatest}\` / stable \`${upstreamStable}\`
-この repo の公開 latest audited release: \`${ourVersion}\`
+この repo の latest audited release (release manifest 基準): \`${ourVersion}\`
 `;
 }
 


### PR DESCRIPTION
Promote 2.1.265 to termux_verified status

This PR updates the version status from offset_discovered to termux_verified after successful Device B verification.

## Changes
- Updated version status in version tracking configs
- Updated release manifest

## Status
- [x] candidate publish completed
- [x] Device B verification passed
- [ ] Code review (G3) - awaiting review
- [ ] Verification review (G4) - awaiting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)