### PR TITLE
fix: correct -repo to --repo flag in create-github-release.yml

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -69,7 +69,7 @@ jobs:
           ver="${{ steps.ver.outputs.ver }}"
           previous_ver="${{ steps.prev.outputs.previous_ver }}"
           tag="v${ver}"
-          if gh release view "$tag" -repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             echo "Release $tag already exists, skipping"
             exit 0
           fi


### PR DESCRIPTION
Fixes invalid gh CLI flag that broke the idempotency check (skip-if-release-exists) in the Create GitHub Release workflow.