### PR TITLE
fix: correct rollback version wording in README generator

### DIFF
--- a/scripts/update-readme-version-guidance.js
+++ b/scripts/update-readme-version-guidance.js
@@ -83,7 +83,7 @@ function updateSupportedVersionsTable(content, latestAudited, previousStable, st
 
   const rows = [
     `| \`${latestAudited}\` | ✅ **Recommended / 推奨** — latest |`,
-    `| \`${previousStable}\` | ✅ rollback candidate — \`@candidate\` dist-tag |`,
+    `| \`${previousStable}\` | ✅ rollback version |`,
   ];
   if (stablePinned && stablePinned !== previousStable && stablePinned !== latestAudited) {
     rows.push(`| \`${stablePinned}\` | ✅ stable — \`@stable\` dist-tag |`);


### PR DESCRIPTION
The generator claimed previousStable is on the @candidate dist-tag, which is only true after promote-and-publish.yml completes the retag. Removes the premature tag claim.