### PR TITLE
Promote claude-code 2.1.269 to termux_verified status

### DIFF
--- a/config/claude-native-audited-versions.json
+++ b/config/claude-native-audited-versions.json
@@ -1786,7 +1786,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-aFhjKAV8ihVlhyeXwRxzC9JpoDinXIMpJFbl+JW3Lc68XhCq5+O27qiryOV0RQ3MtUo1uxoOXrAhX3vUNGjUnA==",
       "tarball_sha256": "61e3610ab8c5d1af961f08a4d7b58b6ec6b220d0e3b777511a0399d306b7c765",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1864,
       "byte_count": 131352394,
       "cycle_hoists": [

--- a/config/claude-termux-release-manifest.json
+++ b/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.268",
+  "latest_audited_version": "2.1.269",
   "latest_candidate_version": "2.1.269",
-  "previous_stable_version": "2.1.265",
+  "previous_stable_version": "2.1.268",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }

--- a/packages/claude-code/config/claude-native-audited-versions.json
+++ b/packages/claude-code/config/claude-native-audited-versions.json
@@ -1786,7 +1786,7 @@
       "entry_format": "esm-chunked",
       "tarball_integrity": "sha512-aFhjKAV8ihVlhyeXwRxzC9JpoDinXIMpJFbl+JW3Lc68XhCq5+O27qiryOV0RQ3MtUo1uxoOXrAhX3vUNGjUnA==",
       "tarball_sha256": "61e3610ab8c5d1af961f08a4d7b58b6ec6b220d0e3b777511a0399d306b7c765",
-      "status": "offset_discovered",
+      "status": "termux_verified",
       "num_modules": 1864,
       "byte_count": 131352394,
       "cycle_hoists": [

--- a/packages/claude-code/config/claude-termux-release-manifest.json
+++ b/packages/claude-code/config/claude-termux-release-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 1,
   "package_name": "@bash0816/claude-code",
-  "latest_audited_version": "2.1.268",
+  "latest_audited_version": "2.1.269",
   "latest_candidate_version": "2.1.269",
-  "previous_stable_version": "2.1.265",
+  "previous_stable_version": "2.1.268",
   "stable_pinned_version": "2.1.220-2",
   "manifest_url": "https://raw.githubusercontent.com/bash0816/ClaudeCode-Termux/main/config/claude-termux-release-manifest.json"
 }


### PR DESCRIPTION
Updates the termux_verified status for claude-code 2.1.269 following successful validation on Device A and Device B.

Changes:
- Updates `claude-native-audited-versions.json` to mark 2.1.269 as `termux_verified`
- Updates `claude-termux-release-manifest.json` with latest audited version
- Maintains version history tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)